### PR TITLE
fix(indexer): index inline module bodies so unit tests are indexed (tethys-s8hv)

### DIFF
--- a/.tethys-s8hv/design.md
+++ b/.tethys-s8hv/design.md
@@ -1,0 +1,84 @@
+# Design — tethys-s8hv: index inline module bodies
+
+## Purpose
+`extract_symbols_recursive`'s `MOD_ITEM` arm (src/languages/rust.rs:954) records
+the module shell but does not recurse into the body, so every symbol inside an
+inline `mod { … }` (dominantly `#[cfg(test)] mod tests`) is dropped. Fix: recurse
+into the module body, mirroring `IMPL_ITEM`.
+
+## What the spike proved (cheapest falsifier — RAN, passed)
+Applied the 5-line recursion, rebuilt, re-indexed:
+- `is_test` 330 → **809** (src/ 0 → 464); oracle ~842 source test fns.
+- symbols 1700 → 2326 (+626).
+- **refs re-attach automatically**: refs with `in_symbol_id` = a src/ unit-test
+  symbol went ~0 → **3909**. The reference walk already recursed into mod bodies;
+  those refs were unattached (NULL `in_symbol_id`) only because the enclosing unit
+  test wasn't a symbol. So NO refs-walk change is needed — the symbol fix suffices.
+- test-suite blast radius: **1 failure** (`deprecated_callers::
+  resolved_sites_cross_file_and_top_level`) — a legitimate caller-attribution
+  improvement, not a break.
+
+## Input shapes
+1. `#[cfg(test)] mod tests { #[test] fn … }` — dominant; unit tests → is_test roots.
+2. Plain inline `mod foo { fn bar }` — non-test inline module (product code).
+3. Nested inline `mod a { mod b { fn c }}` — recursion depth.
+4. Mixed items in a mod (fn, struct, impl, const, nested mod).
+5. Empty inline `mod foo {}` — no body items.
+6. File-module decl `mod foo;` — NO `declaration_list`; must not panic/duplicate.
+7. `#[test] fn` inside the mod — is_test must be set (extract_function path).
+8. proptest!/macro-generated test fns — NOT function_item nodes (OUT of scope).
+
+## Removed-invariant sweep (this change is subtractive)
+Removed invariant: **"symbol/ref tables contain no `#[cfg(test)]` inline-module
+(unit-test) code."** Product-health analyses relied on it. Readers that now see
+test code (none filter test today except panic-points, which already does
+`s.is_test = 0`):
+- **INV-1 visibility-tightening (REGRESSION RISK):** a `pub` item used only by a
+  same-crate unit test currently looks unused → correctly flagged tightenable.
+  After the fix, that test usage suppresses the candidate. Must exclude test refs.
+- **INV-2 unused-imports:** now sees test-module `use` statements (noise vs signal
+  — decision needed).
+- **INV-3 deprecated-callers:** now counts test call sites (the 1 broken fence).
+- **INV-4 coupling / index counts:** +626 symbols shift metrics.
+
+## Falsification
+| # | Claim | Falsifier | Oracle | Cost | Status | Regression fence |
+|---|-------|-----------|--------|------|--------|------------------|
+| 1 | Recursing MOD_ITEM indexes inline-mod symbols | index; `is_excluded_dir_allows_lib` is a symbol | grep confirms it's a `#[test] fn` | 2m | **passed** | fixture test: cfg(test) mod fn is indexed |
+| 2 | Unit test fns get is_test=1 | is_test count ≈ source test-fn count (809 vs 842) | grep test attrs | 2m | **passed** | `.tethys-s8hv/probe.sh` floor + CI count test |
+| 3 | Unit-test→product edges attach | refs with in_symbol_id in src is_test > 0 (3909) | SQL count (independent of symbol walk) | 2m | **passed** | fixture: unit test call → edge to product fn |
+| 4 | `mod foo;` (no body) still indexes, no panic | index a file-module; module symbol present, no dup | existing file-module symbol counts unchanged | 2m | pending | existing module tests |
+| 5 | Nested inline mods index innermost fn | fixture `mod a{mod b{fn c}}`; c is a symbol | grep fixture source | 5m | pending | fixture test |
+| 6 | INV-1: pub item used only by unit test STILL flagged tightenable | fixture: `pub fn` called only from `#[cfg(test)]`; run visibility-tightening | manual/grep on fixture | 15m | **pending (LIKELY FAILS w/ minimal fix)** | fixture test in visibility suite |
+| 7 | Blast radius bounded to known fences | full nextest | nextest | 20s | **passed** (1 expected) | updated deprecated-callers fence |
+
+Claim 6 is the load-bearing one: it fails unless the fix also excludes test refs
+from visibility-tightening.
+
+## Negative space (what this fix deliberately does NOT do)
+1. Does NOT index proptest!/macro-generated test functions (they're macro nodes,
+   not function_item) — separate gap, filed as **tethys-0nar**.
+2. Does NOT propagate is_test to non-attribute test *helper* fns inside cfg(test)
+   modules (they keep is_test=0) — a "test-context" flag is out of scope (see
+   tethys-m7zm for the shared-lever discussion).
+3. Does NOT touch the C# extractor (namespace/class recursion already works).
+4. Does NOT redesign unused-imports / deprecated-callers test handling beyond the
+   minimal fence update — those semantics are filed as **tethys-m7zm**.
+
+## Approved scope: A (2026-07-04)
+Indexing fix + exclude test refs from visibility-tightening (close INV-1) +
+update deprecated-callers fence + fences for claims 1–5. Follow-ups filed:
+tethys-0nar (proptest fns), tethys-m7zm (unused-imports/deprecated-callers policy).
+
+## Scope decision (for approval)
+The bug fix is 5 lines. The DECISION is how much analysis-side test-handling
+rides with it, given INV-1 is a real regression:
+- **A (recommended):** indexing fix + exclude test refs from visibility-tightening
+  (close INV-1) + update the deprecated-callers fence (INV-3) + fences for
+  claims 1–5. File follow-ups for unused-imports test handling (INV-2) and
+  proptest-macro-fn indexing.
+- **B (minimal):** indexing fix + fence updates only; accept INV-1 regression and
+  file it. Faster, but ships a known visibility-tightening regression — violates
+  the PRD trust bar.
+- **C (comprehensive):** A + a test-context flag + test filtering across all
+  product-health analyses in one PR. Largest; likely over-scoped for one issue.

--- a/.tethys-s8hv/findings.md
+++ b/.tethys-s8hv/findings.md
@@ -1,0 +1,50 @@
+# prove-it-prototype findings — tethys-y3bx (untested-code)
+
+## Smallest question
+"Do the `is_test` roots the analysis depends on match the test functions that
+actually exist in the source?"
+
+## Probe (against real self-index, freshly rebuilt with current-source binary)
+`SELECT COUNT(*) FROM symbols WHERE is_test=1;` → **330**, ALL in `tests/`.
+
+## Oracle (independent — grep the source)
+`#[test]` in src/ = 467, in tests/ = 353; + `#[tokio::test]` 5 + `#[rstest]` 17
+≈ **842 test functions**. Cross-checked against `cargo nextest`: 843 test cases.
+
+## Disagreement: 330 vs ~842 (probe finds ~40% of test roots)
+Not a staleness artifact — a clean re-index with a from-current-source binary
+moved it 327→330. Root-caused to a real substrate bug.
+
+## Root cause (code + data confirmed)
+`src/languages/rust.rs:954` — the `MOD_ITEM` arm of `extract_symbols_recursive`
+records the module as a `SymbolKind::Module` symbol but **does not recurse into
+the module body (`declaration_list`)**, unlike the `_` default arm (rust.rs:959)
+and `IMPL_ITEM` (rust.rs:917). So every symbol declared inside an inline
+`mod { … }` block is dropped. `#[cfg(test)] mod tests { #[test] fn … }` is
+exactly such a block.
+
+Data confirming the mechanism:
+- 26 `tests` module SHELL symbols exist (kind=module); their bodies are empty.
+- 0 unit-test functions indexed (known unit tests `is_excluded_dir_allows_lib`,
+  `normalize_path_is_idempotent`, `extracts_simple_function` → not symbols).
+- 212 src/ function symbols exist — all PRODUCT top-level functions.
+- 4449 refs originate from `is_test` symbols — all from tests/ integration tests.
+
+## Why this GATES untested-code
+The analysis reports symbols not reachable from any `is_test` root. With
+unit tests absent as roots AND their edges into product code absent from
+`refs`, every function covered ONLY by a unit test (the majority on a
+unit-test-heavy codebase) would be FALSELY reported "untested." That inverts
+the PRD's near-zero-false-positive requirement — the whole value proposition.
+
+## What I learned that I didn't know before probing
+tethys does not index inline module bodies at all — so `is_test` covers only
+integration tests, and unit-test coverage is invisible to the reference graph.
+The y3bx spec's premise ("test detection already exists") is false for the
+dominant test form on this codebase.
+
+## Recommendation
+STOP untested-code. File the inline-module-body indexing bug; it blocks y3bx
+(and improves is_test / reachability / dead-code broadly). The fix has a real
+blast radius (indexing test code changes what every analysis sees) and deserves
+its own design pass, not a bolt-on.

--- a/.tethys-s8hv/plan.md
+++ b/.tethys-s8hv/plan.md
@@ -1,0 +1,127 @@
+# Plan — tethys-s8hv (Scope A): index inline module bodies
+
+Two slices. Slice 1 is the atomic indexing fix + its forced fence updates.
+Slice 2 closes the visibility-tightening regression (INV-1), red-first.
+
+---
+
+## Slice 1: Recurse `MOD_ITEM` into inline module bodies
+
+**Claim:** Symbols (esp. `#[cfg(test)] mod tests` unit tests) declared inside an
+inline `mod { … }` are indexed; their refs re-attach to them; file-module
+declarations (`mod foo;`) and nested/empty inline mods still index correctly.
+(Design claims 1–5, 7.)
+
+**Oracle:** `.tethys-s8hv/probe.sh` — is_test src/ count > 0, the three named
+known unit tests present with is_test=1, independent of the extractor (SQL +
+grep). Plus full `cargo nextest`.
+
+**Stress fixture:** `tests/inline_module_indexing.rs` builds a fixture workspace with:
+- `#[cfg(test)] mod tests { #[test] fn t() { product_fn(); } }` → `t` is a symbol
+  with is_test=1 AND a resolved ref edge `t → product_fn` exists (edge attach).
+- nested `mod a { mod b { fn c() {} } }` → `c` is indexed (recursion depth).
+- `mod decl_only;` sibling file-module → module symbol present, no panic, not duplicated.
+- empty `mod e {}` → module symbol, zero body symbols, no panic.
+Expected outputs written in the test as assertions BEFORE implementing.
+
+**Loop budget:** No new loop. The recursion reuses the existing single tree walk
+(`extract_symbols_recursive`), now descending into `mod` bodies via the same
+`node.children()` iteration the `_` arm already uses. Cost O(nodes-per-file),
+unchanged; each node visited once (MOD_ITEM is a disjoint match arm — no double
+visit). Production scale: total AST nodes across files; no threshold concern.
+
+**Wall budget:** n/a (indexing is on-demand, not always-on). Spike measured
+self-index 1.1s at +626 symbols — no regression concern.
+
+**Files:**
+- `src/languages/rust.rs` (the ~5-line recursion in the `MOD_ITEM` arm, ~line 954)
+- `tests/inline_module_indexing.rs` (new fence)
+- `tests/deprecated_callers.rs` (FORCED golden update: `resolved_sites_cross_file_and_top_level` — the tests-mod call now attaches to a unit-test symbol; update the expected caller. Not new logic — a golden-expectation change the indexing behavior forces. Justifies the 3rd file.)
+
+**Code (advisory):**
+```rust
+MOD_ITEM => {
+    if let Some(sym) = extract_simple_definition(node, content, SymbolKind::Module) {
+        symbols.push(sym);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        extract_symbols_recursive(&child, content, symbols, parent_name);
+    }
+}
+```
+
+**Verification:**
+- [ ] Unit tests pass (`tests/inline_module_indexing.rs`)
+- [ ] Stress fixture produces expected outcome (edge attach + nested + no-body + empty)
+- [ ] `probe.sh` flips to ✅ (unit tests indexed, edges attach)
+- [ ] Full `cargo nextest` green (deprecated-callers fence updated)
+- [ ] Loop budget holds (no new loop; self-index time unchanged)
+
+---
+
+## Slice 2: Exclude same-crate unit-test usage from visibility-tightening (INV-1)
+
+**Claim:** A `pub` item used ONLY by a same-crate `#[cfg(test)]` unit test is
+STILL reported as a tightening candidate; an item used by product code OR by an
+integration test (cross-crate) is NOT. (Design claim 6.)
+
+**Oracle:** Fixture-built index + `tethys visibility-tightening --json`. Independent
+of the SUT internals: grep the fixture confirms the only non-test caller is absent.
+
+**Stress fixture:** `tests/visibility.rs` (extend) — fixture crate with:
+- `pub fn only_unit_tested()` called only from `#[cfg(test)] mod tests` → MUST be a
+  candidate (the regression case).
+- `pub fn used_by_product()` called from a non-test fn → MUST NOT be a candidate
+  (real usage still suppresses — guards against over-broadly dropping refs).
+- `pub fn used_by_integration()` referenced from a `tests/` integration file →
+  MUST NOT be a candidate (cross-crate test usage = real public API need).
+Expected candidate set written BEFORE implementation.
+
+**Red-first note:** Write the fixture and RUN it before touching `visibility.rs`.
+If `only_unit_tested` already stays a candidate (existing root-reachable/same-pkg
+logic absorbs it), the code change is unnecessary — ship the fence only. If it
+regresses (predicted), add the exclusion.
+
+**Smallest code change (advisory):** In the usage-evidence query that suppresses a
+candidate (`src/db/visibility.rs`), exclude refs whose caller symbol is `is_test=1`
+AND in the SAME package as the item. Keep cross-package refs (integration tests,
+real consumers). Exact predicate determined in build against the fixture.
+
+**Loop budget:** No new loop — adds a predicate to an existing per-candidate
+evidence query. Cost O(refs) as before; production scale refs ≈ 10^4–10^5, single
+indexed SQL pass. Within budget.
+
+**Files:**
+- `src/db/visibility.rs` (evidence-query predicate; only if fixture goes red)
+- `tests/visibility.rs` (fixture fence)
+
+**Verification:**
+- [ ] Unit tests pass (all three fixture cases)
+- [ ] Stress fixture: only_unit_tested IS a candidate; used_by_product and
+      used_by_integration are NOT
+- [ ] prove-it-prototype oracle (probe.sh) still ✅ from slice 1
+- [ ] Full `cargo nextest` green
+- [ ] Loop budget holds (no new loop)
+
+---
+
+## Plan Self-Review
+
+1. **Loops:** Slice 1 — no new loop (reuses tree walk, O(nodes), within budget).
+   Slice 2 — no new loop (SQL predicate on existing O(refs) query). No gaps.
+2. **Fixtures:** Slice 1 fixture designed to fail on: missing recursion (edge
+   won't attach), shallow recursion (nested `c` missing), no-body panic
+   (`mod foo;`), empty-mod panic. Slice 2 fixture designed to fail on: over-broad
+   ref-drop (used_by_product wrongly becomes candidate) and cross-crate confusion
+   (used_by_integration wrongly becomes candidate). Both beyond happy-path. No gaps.
+3. **Doc-comment preconditions:** None introduced (no new `callers must X` contracts).
+   The MOD_ITEM recursion has no precondition; the visibility predicate is internal.
+   No gaps.
+4. **Write targets:** Slice 1 — test assertions only (no new println!). Slice 2 —
+   candidates already flow to stdout as data via existing `--json`; no new writes.
+   No gaps.
+5. **Tracker references:** Deferrals cite tethys-0nar (proptest fns) and tethys-m7zm
+   (unused-imports/deprecated-callers policy), both filed and verified. Slice 1's
+   deprecated-callers fence update is the ACCEPTED policy for that analysis (test
+   call sites count); the broader question is tethys-m7zm. No gaps.

--- a/.tethys-s8hv/probe.sh
+++ b/.tethys-s8hv/probe.sh
@@ -27,9 +27,13 @@ oracle=$(( o_test + o_tokio + o_rstest ))
 echo "PROBE  (index):  is_test=$probe_is_test   (of which in src/: $probe_in_src)"
 echo "ORACLE (source): ~$oracle test fns (#[test] $o_test + tokio $o_tokio + rstest $o_rstest)"
 
+# Known plain-#[test] unit tests inside inline `#[cfg(test)] mod tests` blocks.
+# NOTE: proptest!-macro-generated test fns (e.g. normalize_path_is_idempotent)
+# are NOT function_item nodes and stay unindexed — that is tethys-0nar, out of
+# scope here — so they are deliberately absent from this list.
 echo "--- known unit tests (must be is_test=1 symbols after the fix) ---"
 fail=0
-for n in is_excluded_dir_allows_lib normalize_path_is_idempotent extracts_simple_function; do
+for n in is_excluded_dir_allows_lib extracts_simple_function; do
   got=$(sqlite3 "$DB" "SELECT is_test FROM symbols WHERE name='$n' LIMIT 1;")
   if [ "$got" = "1" ]; then echo "  OK   $n (is_test=1)"; else echo "  MISS $n (indexed=${got:-no})"; fail=1; fi
 done

--- a/.tethys-s8hv/probe.sh
+++ b/.tethys-s8hv/probe.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# probe.sh — tethys-s8hv oracle: does the index capture unit tests?
+#
+# PROBE (index): count is_test symbols; check known unit tests are present.
+# ORACLE (source, independent): count #[test]/#[tokio::test]/#[rstest] in src+tests.
+#
+# Before the fix: is_test≈330 (integration only), known unit tests ABSENT.
+# After recursing MOD_ITEM into declaration_list: is_test should approach the
+# source count and the known unit tests should be indexed with is_test=1.
+#
+# This is the cheapest falsifier for the fix. Run: bash .tethys-s8hv/probe.sh
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 2
+
+DB=.rivets/index/tethys.db
+[ -f "$DB" ] || { echo "no index at $DB — run: tethys index -w ."; exit 2; }
+
+probe_is_test=$(sqlite3 "$DB" "SELECT COUNT(*) FROM symbols WHERE is_test=1;")
+probe_in_src=$(sqlite3 "$DB" "SELECT COUNT(*) FROM symbols s JOIN files f ON s.file_id=f.id WHERE s.is_test=1 AND f.path NOT LIKE '%/tests/%' AND f.path NOT LIKE 'tests/%';")
+
+# Oracle: independent source count.
+o_test=$(grep -rn -E '^\s*#\[test\]' src tests 2>/dev/null | wc -l | tr -d ' ')
+o_tokio=$(grep -rn -E '#\[tokio::test\]' src tests 2>/dev/null | wc -l | tr -d ' ')
+o_rstest=$(grep -rn -E '^\s*#\[rstest\]' src tests 2>/dev/null | wc -l | tr -d ' ')
+oracle=$(( o_test + o_tokio + o_rstest ))
+
+echo "PROBE  (index):  is_test=$probe_is_test   (of which in src/: $probe_in_src)"
+echo "ORACLE (source): ~$oracle test fns (#[test] $o_test + tokio $o_tokio + rstest $o_rstest)"
+
+echo "--- known unit tests (must be is_test=1 symbols after the fix) ---"
+fail=0
+for n in is_excluded_dir_allows_lib normalize_path_is_idempotent extracts_simple_function; do
+  got=$(sqlite3 "$DB" "SELECT is_test FROM symbols WHERE name='$n' LIMIT 1;")
+  if [ "$got" = "1" ]; then echo "  OK   $n (is_test=1)"; else echo "  MISS $n (indexed=${got:-no})"; fail=1; fi
+done
+
+echo "----------------------------------------"
+if [ "$probe_in_src" -gt 0 ] && [ "$fail" -eq 0 ]; then
+  echo "✅ unit tests ARE indexed (fix working)"
+else
+  echo "❌ unit tests NOT indexed (bug present): src is_test=$probe_in_src, known-test miss=$fail"
+fi

--- a/.tethys-s8hv/related-issues.md
+++ b/.tethys-s8hv/related-issues.md
@@ -1,0 +1,23 @@
+# Related issues — tethys-y3bx (untested-code analysis)
+
+Prior-art search (rivets, 2026-07-04). `rivets list --search` is a no-op flag;
+used `rivets list -n 500 | grep`.
+
+- **tethys-3gey** (CLOSED) — Reachability analysis (forward/backward). The
+  existing machinery y3bx reuses: `Tethys::bfs_reachable` /
+  `get_forward_reachable` / `get_backward_reachable` (src/lib.rs:544+),
+  backed by `get_callees`/`get_callers` over the **call_edges** table.
+- **tethys-o6x7** (CLOSED) — Test topology mapping. The feature that
+  INTRODUCED `is_test`. Its description claims "✅ Index all symbols including
+  test functions" — the intent the probe falsifies (see findings.md).
+- **tethys-dvsw** (open, P3) — Dead-code finder; the roadmap stage AFTER
+  untested-code. Same reverse-traversal machinery.
+- **tethys-7p54** (open, P3) — Hotspots (connectivity ranking).
+- **tethys-ygjx** (open) — fn-as-value refs gap. y3bx documents this as a
+  known, non-blocking limitation.
+- **tethys-l6nt** (PRD, parent) — Act 1 code-health analyzer roadmap.
+
+## New finding (unfiled at probe time)
+call_edges is a lossy subset of refs (schema.rs:122: "both in_symbol_id and
+symbol_id resolved"). SEPARATELY: inline module bodies are not indexed at all
+(root cause below) — the dominant blocker, not the call_edges/refs distinction.

--- a/src/languages/rust.rs
+++ b/src/languages/rust.rs
@@ -955,6 +955,14 @@ fn extract_symbols_recursive(
             if let Some(sym) = extract_simple_definition(node, content, SymbolKind::Module) {
                 symbols.push(sym);
             }
+            // Recurse into the inline module body (`declaration_list`) so symbols
+            // declared inside `mod { … }` — including `#[cfg(test)] mod tests`
+            // unit tests — are indexed. A file-module declaration (`mod foo;`) has
+            // no body, so this loop simply finds nothing to recurse into.
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                extract_symbols_recursive(&child, content, symbols, parent_name);
+            }
         }
         _ => {
             // Recurse into children for containers we don't explicitly handle

--- a/src/languages/rust.rs
+++ b/src/languages/rust.rs
@@ -955,13 +955,19 @@ fn extract_symbols_recursive(
             if let Some(sym) = extract_simple_definition(node, content, SymbolKind::Module) {
                 symbols.push(sym);
             }
-            // Recurse into the inline module body (`declaration_list`) so symbols
-            // declared inside `mod { … }` — including `#[cfg(test)] mod tests`
-            // unit tests — are indexed. A file-module declaration (`mod foo;`) has
-            // no body, so this loop simply finds nothing to recurse into.
+            // Recurse into the inline module body so symbols declared inside
+            // `mod { … }` — including `#[cfg(test)] mod tests` unit tests — are
+            // indexed. Target `DECLARATION_LIST` explicitly (as the `IMPL_ITEM`
+            // arm does), skipping the `mod` keyword / name / visibility children;
+            // a file-module declaration (`mod foo;`) has no body, so nothing recurses.
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
-                extract_symbols_recursive(&child, content, symbols, parent_name);
+                if child.kind() == DECLARATION_LIST {
+                    let mut body_cursor = child.walk();
+                    for item in child.children(&mut body_cursor) {
+                        extract_symbols_recursive(&item, content, symbols, parent_name);
+                    }
+                }
             }
         }
         _ => {

--- a/tests/deprecated_callers.rs
+++ b/tests/deprecated_callers.rs
@@ -100,7 +100,12 @@ fn resolved_sites_cross_file_and_top_level() {
     assert_eq!(
         sites,
         vec![
-            ("src/caller.rs:14".to_string(), None), // tests-mod call: top-level ref
+            // tests-mod call: now attributed to the enclosing unit-test fn
+            // (was top-level/None before tethys-s8hv indexed inline mod bodies).
+            (
+                "src/caller.rs:14".to_string(),
+                Some("exercises_old".to_string()),
+            ),
             ("src/caller.rs:4".to_string(), Some("migrate".to_string())),
         ],
         "old_api should list exactly the imported cross-file call and the tests-mod call"

--- a/tests/test_topology.rs
+++ b/tests/test_topology.rs
@@ -578,3 +578,143 @@ fn test_func_b() {
         );
     }
 }
+
+/// Regression fence for tethys-s8hv: symbols inside inline `mod { … }` blocks
+/// (dominantly `#[cfg(test)] mod tests`) must be indexed. The extractor's
+/// `MOD_ITEM` arm previously recorded the module shell but did not recurse into
+/// its body, so unit tests, their `is_test` flag, and their reference edges were
+/// all dropped. Every prior test in this file used top-level `#[test]`, which is
+/// why the bug survived.
+mod inline_module_indexing {
+    use super::*;
+
+    #[test]
+    fn unit_test_inside_cfg_test_mod_is_indexed() {
+        let (_dir, mut tethys) = workspace_with_files(&[(
+            "src/lib.rs",
+            r#"
+pub fn production_helper() -> i32 {
+    42
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_test_in_mod() {
+        assert_eq!(production_helper(), 42);
+    }
+}
+"#,
+        )]);
+
+        tethys.index().expect("index failed");
+        let tests = tethys.get_test_symbols().expect("get_test_symbols failed");
+
+        assert!(
+            tests
+                .iter()
+                .any(|s| s.name == "unit_test_in_mod" && s.is_test),
+            "unit test inside `#[cfg(test)] mod tests` must be indexed with is_test=1; got: {:?}",
+            tests.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn unit_test_call_edge_attaches_to_test_symbol() {
+        let (_dir, mut tethys) = workspace_with_files(&[(
+            "src/lib.rs",
+            r#"
+pub fn production_helper() -> i32 {
+    42
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calls_helper() {
+        let _ = production_helper();
+    }
+}
+"#,
+        )]);
+
+        tethys.index().expect("index failed");
+        // The test's call into product code must be a real graph edge. Discover
+        // the test symbol's qualified name (inline-mod qualified-name format is
+        // not hardcoded here) and confirm production_helper is forward-reachable.
+        let test_sym = tethys
+            .get_test_symbols()
+            .expect("get_test_symbols failed")
+            .into_iter()
+            .find(|s| s.name == "calls_helper")
+            .expect("calls_helper must be an indexed test symbol");
+        let reachable = tethys
+            .get_forward_reachable(&test_sym.qualified_name, Some(2))
+            .expect("get_forward_reachable failed");
+        assert!(
+            reachable
+                .reachable
+                .iter()
+                .any(|r| r.target.name == "production_helper"),
+            "unit test's call edge to production_helper must attach; reachable: {:?}",
+            reachable
+                .reachable
+                .iter()
+                .map(|r| &r.target.name)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn nested_inline_modules_are_indexed() {
+        let (_dir, mut tethys) = workspace_with_files(&[(
+            "src/lib.rs",
+            r#"
+mod outer {
+    pub mod inner {
+        #[test]
+        fn deep_test() {
+            assert!(true);
+        }
+    }
+}
+"#,
+        )]);
+
+        tethys.index().expect("index failed");
+        let tests = tethys.get_test_symbols().expect("get_test_symbols failed");
+        assert!(
+            tests.iter().any(|s| s.name == "deep_test" && s.is_test),
+            "test in a doubly-nested inline module must be indexed; got: {:?}",
+            tests.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn empty_inline_module_does_not_break_indexing() {
+        // An empty inline module plus a top-level fn must index without panic.
+        let (_dir, mut tethys) = workspace_with_files(&[(
+            "src/lib.rs",
+            r#"
+mod empty {}
+
+pub fn top_level() -> i32 {
+    1
+}
+"#,
+        )]);
+
+        tethys
+            .index()
+            .expect("index of workspace with empty inline module failed");
+        let syms = tethys.search_symbols("top_level").expect("search failed");
+        assert!(
+            syms.iter().any(|s| s.name == "top_level"),
+            "top-level fn must still be indexed alongside an empty inline module"
+        );
+    }
+}

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -576,3 +576,41 @@ fn scope_excludes_nonpublic_and_members() {
         );
     }
 }
+
+/// Regression fence for tethys-s8hv / INV-1. Once inline-module bodies became
+/// indexed, a `#[cfg(test)] mod tests` unit test produces reference edges into
+/// the code it exercises. A `pub` item used ONLY by such a same-crate unit test
+/// must STILL be a Definite tightening candidate: visibility-tightening's
+/// keep-public evidence is cross-PACKAGE usage, and a same-crate unit test is
+/// same-package. The design predicted this would regress; a red-first experiment
+/// disproved it. This fence locks the behavior so a future change that starts
+/// counting same-crate test refs as keep-public evidence fails loudly.
+#[test]
+fn same_crate_unit_test_usage_does_not_suppress_tightening_candidate() {
+    let (dir, mut tethys) = workspace_with_files(&[
+        ("src/lib.rs", "pub mod api;\nmod internal;\n"),
+        ("src/api.rs", "pub fn exposed() {}\n"),
+        (
+            "src/internal.rs",
+            "pub fn buried() {}\n\
+             \n\
+             #[cfg(test)]\n\
+             mod tests {\n\
+             use super::*;\n\
+             #[test]\n\
+             fn exercises_buried() {\n\
+             buried();\n\
+             }\n\
+             }\n",
+        ),
+    ]);
+    tethys.index().expect("index failed");
+
+    let table = run_cli(&dir, &[]);
+    assert!(
+        table.contains("[Definite]") && table.contains("buried"),
+        "a pub fn used only by a same-crate #[cfg(test)] unit test must remain a \
+         Definite tightening candidate (same-crate test usage is not keep-public \
+         evidence):\n{table}"
+    );
+}

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -606,11 +606,19 @@ fn same_crate_unit_test_usage_does_not_suppress_tightening_candidate() {
     ]);
     tethys.index().expect("index failed");
 
-    let table = run_cli(&dir, &[]);
-    assert!(
-        table.contains("[Definite]") && table.contains("buried"),
+    // Parse JSON and pin `buried`'s tier specifically (not just "some Definite
+    // exists and 'buried' appears somewhere") so the fence stays precise if the
+    // fixture ever grows another candidate.
+    let json = run_cli(&dir, &["--json"]);
+    let value: serde_json::Value = serde_json::from_str(&json).expect("stdout parses as JSON");
+    let findings = value["findings"].as_array().expect("findings array");
+    let buried = findings
+        .iter()
+        .find(|f| f["name"] == "buried")
+        .unwrap_or_else(|| panic!("buried must be a tightening candidate; findings: {findings:?}"));
+    assert_eq!(
+        buried["tier"], "Definite",
         "a pub fn used only by a same-crate #[cfg(test)] unit test must remain a \
-         Definite tightening candidate (same-crate test usage is not keep-public \
-         evidence):\n{table}"
+         Definite tightening candidate (same-crate test usage is not keep-public evidence)"
     );
 }


### PR DESCRIPTION
Closes tethys-s8hv — the Rust extractor now indexes symbols inside inline `mod { … }` bodies (dominantly `#[cfg(test)] mod tests` unit tests).

## What this does
`extract_symbols_recursive`'s `MOD_ITEM` arm recorded the module shell but never recursed into the body (`declaration_list`), so every symbol inside an inline module was dropped. The fix recurses into the body, mirroring `IMPL_ITEM`. Self-index `is_test` jumps **330 → 813** (src/ 0 → 464); unit-test reference edges re-attach automatically — the reference walk already recursed into mod bodies, so those refs were captured all along but had no symbol to bind `in_symbol_id` to. This unblocks **tethys-y3bx** (untested-code analysis).

## Scope (approved: A)
Indexing fix + INV-1 guard for visibility-tightening + regression fences. Blast radius measured at **1** pre-existing golden expectation (deprecated-callers caller attribution improved, updated in this PR).

## Acceptance criteria
- [x] Symbols inside `#[cfg(test)] mod tests` indexed with `is_test=1` — `test_topology::inline_module_indexing::unit_test_inside_cfg_test_mod_is_indexed`
- [x] Unit-test → product reference edges attach — `…::unit_test_call_edge_attaches_to_test_symbol`
- [x] Nested inline modules recurse — `…::nested_inline_modules_are_indexed`
- [x] Empty `mod {}` / `mod foo;` index without panic — `…::empty_inline_module_does_not_break_indexing` + existing module tests
- [x] Pub item used only by a same-crate unit test stays a Definite tightening candidate (INV-1) — `visibility::same_crate_unit_test_usage_does_not_suppress_tightening_candidate`
- [x] Full suite green (848 tests) with deprecated-callers golden updated

## Method + evidence
Full gilfoyle loop; audit trail in `.tethys-s8hv/` (`probe.sh` oracle, `findings.md`, `design.md`, `plan.md`). Oracle result: is_test src/ 0 → 464, known unit tests indexed, 3909 unit-test edges attach. The design predicted an INV-1 regression in visibility-tightening; a red-first experiment **disproved** it (keep-public evidence is cross-package, so same-crate test usage never counted) — the fence locks that in. Pre-PR `rust-code-reviewer`: no defects; one fence hardened (JSON tier pin) per its suggestion.

## Discovered and filed
- **tethys-0nar** — `proptest!`/macro-defined test fns remain unindexed (function-in-macro gap; ~36 residual test fns, `is_test` 813 vs ~849 source).
- **tethys-m7zm** — decide unused-imports / deprecated-callers policy on newly-indexed test code.

## Notable behavior changes
Every analysis now sees `#[cfg(test)]` inline-module code. Verified blast radius = 1 test (deprecated-callers caller attribution). panic-points already filters `is_test=0`; visibility-tightening confirmed unaffected by the INV-1 fence.
