### PR TITLE
ci(changelog): add fragment-based changelog discipline

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -81,6 +81,16 @@ directions); commit fixes as their own conventional commits. Doing this
 pre-PR means the PR opens already-reviewed instead of collecting bot
 churn.
 
+Also before the PR: write the changelog fragment
+`changelog.d/<rivets-id>.<category>.md` — category one of
+added/changed/deprecated/removed/fixed/security; 1-5 bullets written for
+CLI users (name commands, flags, observable behavior; no rivets IDs or
+slice numbers — the PR body carries that story). Commit it
+(`docs(changelog): fragment for <id>`, or ride it with a review-fix
+commit). The `changelog` CI job blocks fragment-less PRs;
+`tests/changelog_lint.rs` fences the format; docs/CI-only PRs take the
+`skip-changelog` label instead. Never edit CHANGELOG.md on a branch.
+
 ## 4. Open the PR
 
 Push (`git push -u origin <branch>`), then `gh pr create` with the house

--- a/.claude/skills/sweep-bugs/SKILL.md
+++ b/.claude/skills/sweep-bugs/SKILL.md
@@ -60,6 +60,12 @@ discover on its own:
 - **Commit format**: conventional, ONE lowercase scope, no commas —
   CI regex `^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\([a-z][a-z0-9-]*\))?!?: .{3,}`.
   Subject cites the rivets ID: `fix(languages): ... (tethys-lwsc)`.
+- **Changelog fragment**: add `changelog.d/<rivets-id>.fixed.md` with one
+  user-facing bullet (what a CLI user sees fixed — no rivets jargon; the
+  PR body carries the repro/cause story). Required: the `changelog` CI
+  job blocks fragment-less PRs; format fenced by
+  `tests/changelog_lint.rs`. Distinct per-issue filenames are why
+  parallel sweep PRs never conflict here — NEVER edit CHANGELOG.md.
 - **Never touch `.rivets/`** — the tracker belongs to the orchestrator;
   a jsonl change in two branches conflicts at merge nearly every time.
   Discovered side-issues go in the report, not the tracker.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,57 @@ jobs:
           echo ""
           echo "All commits follow conventional format!"
 
+  # Require a changelog fragment in every PR (label skip-changelog to exempt).
+  # Presence is checked here (only CI sees the PR diff); the fragment's
+  # format is fenced by tests/changelog_lint.rs in the test job.
+  changelog:
+    name: Changelog Fragment
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for a changelog fragment
+        env:
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+        run: |
+          if [[ " ${PR_LABELS} " == *" skip-changelog "* ]]; then
+            echo "skip-changelog label present — no fragment required"
+            exit 0
+          fi
+
+          # Fetch base branch to ensure it's available
+          git fetch origin ${{ github.base_ref }}
+
+          # Fragments are ADDED files: each PR ships its own distinct file
+          # (that's what keeps parallel PRs conflict-free), so a merge-base
+          # diff filtered to additions is the whole check.
+          if ! DIFF=$(git diff --name-only --diff-filter=A \
+            "origin/${{ github.base_ref }}...HEAD" -- 'changelog.d/*.md'); then
+            echo "❌ git diff against the base branch failed"
+            exit 1
+          fi
+          FRAGMENTS=$(grep -v '^changelog.d/README\.md$' <<< "$DIFF" || true)
+
+          if [[ -z "$FRAGMENTS" ]]; then
+            echo "❌ No changelog fragment in this PR."
+            echo ""
+            echo "Add changelog.d/<id>.<category>.md — id is the rivets ID,"
+            echo "category one of: added changed deprecated removed fixed security —"
+            echo "with 1-5 user-facing bullets (see changelog.d/README.md)."
+            echo ""
+            echo "Docs/CI/chore-only PRs: apply the 'skip-changelog' label instead."
+            echo "The label is read at event time — after adding it, re-run this"
+            echo "check or push again."
+            exit 1
+          fi
+
+          echo "✅ Changelog fragment(s):"
+          echo "$FRAGMENTS"
+
   format:
     name: Format
     runs-on: ubuntu-latest
@@ -231,15 +282,21 @@ jobs:
   ci-success:
     name: CI Success
     if: always()
-    needs: [commitlint, format, lint, test, build, cargo-deny, coverage]
+    needs: [commitlint, changelog, format, lint, test, build, cargo-deny, coverage]
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs
         run: |
-          # commitlint is skipped on push events, so we allow "skipped" result
+          # commitlint and changelog are skipped on push events, so we
+          # allow "skipped" result for both
           if [[ "${{ needs.commitlint.result }}" != "success" ]] && \
              [[ "${{ needs.commitlint.result }}" != "skipped" ]]; then
             echo "Commit validation failed"
+            exit 1
+          fi
+          if [[ "${{ needs.changelog.result }}" != "success" ]] && \
+             [[ "${{ needs.changelog.result }}" != "skipped" ]]; then
+            echo "Changelog fragment check failed"
             exit 1
           fi
           if [[ "${{ needs.format.result }}" != "success" ]] || \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,150 @@
+name: Release
+
+# Triggered by pushing a v* tag (see scripts/changelog-release.sh for the
+# assembly + tagging steps). Verifies the release invariants BEFORE building
+# anything: a release with a missing/empty changelog section or a version
+# mismatch must fail loudly, never publish silently.
+
+on:
+  push:
+    tags: ["v*"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+
+jobs:
+  verify:
+    name: Verify Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check tag matches Cargo.toml version
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if ! grep -q "^version = \"${VERSION}\"$" Cargo.toml; then
+            echo "❌ Tag ${GITHUB_REF_NAME} does not match Cargo.toml:"
+            grep -m1 '^version = ' Cargo.toml
+            exit 1
+          fi
+          echo "✅ Cargo.toml version matches ${GITHUB_REF_NAME}"
+
+      - name: Check CHANGELOG.md has this release's section
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if ! grep -q "^## \[${VERSION}\]" CHANGELOG.md; then
+            echo "❌ CHANGELOG.md has no '## [${VERSION}]' section — run"
+            echo "   scripts/changelog-release.sh ${VERSION} before tagging"
+            exit 1
+          fi
+          echo "✅ CHANGELOG.md section found"
+
+      - name: Check no unconsumed fragments
+        run: |
+          LEFTOVER=$(find changelog.d -name '*.md' ! -name 'README.md')
+          if [[ -n "$LEFTOVER" ]]; then
+            echo "❌ Unconsumed changelog fragments — the release commit must"
+            echo "   consume every fragment (scripts/changelog-release.sh):"
+            echo "$LEFTOVER"
+            exit 1
+          fi
+          echo "✅ No leftover fragments"
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Dry-run publish (packaging sanity)
+        run: cargo publish --dry-run --locked
+
+  build:
+    name: Build Release Binaries
+    runs-on: ${{ matrix.os }}
+    needs: verify
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --release --all-features --locked
+
+      - name: Upload binary (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tethys-linux
+          path: target/release/tethys
+
+      - name: Upload binary (macOS)
+        if: matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tethys-macos
+          path: target/release/tethys
+
+      - name: Upload binary (Windows)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tethys-windows
+          path: target/release/tethys.exe
+
+  release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    needs: [verify, build]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Extract release notes from CHANGELOG.md
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v ver="$VERSION" '
+            index($0, "## [" ver "]") == 1 { found = 1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          if ! grep -q '[^[:space:]]' release-notes.md; then
+            echo "❌ Extracted release notes are empty"
+            exit 1
+          fi
+          echo "── release notes ──"
+          cat release-notes.md
+
+      - name: Stage release assets
+        run: |
+          mv dist/tethys-linux/tethys tethys-linux
+          mv dist/tethys-macos/tethys tethys-macos
+          mv dist/tethys-windows/tethys.exe tethys-windows.exe
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release-notes.md \
+            tethys-linux tethys-macos tethys-windows.exe

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,17 @@ Things the pipeline enforces that an agent should not violate
 - **Conventional commits** are validated in CI (commitlint). Format:
   `<type>(<scope>): <desc>`; types: feat/fix/docs/style/refactor/perf/test/
   build/ci/chore; scopes are lowercase (e.g. `lsp`, `db`, `languages`, `cli`).
+- **Changelog fragments** are required per PR (`changelog` CI job): add
+  `changelog.d/<rivets-id>.<category>.md` — category one of
+  added/changed/deprecated/removed/fixed/security — with 1-5 bullets written
+  for CLI users (the commit log carries the internal narrative; see
+  `changelog.d/README.md`). Format is fenced by `tests/changelog_lint.rs`;
+  the `skip-changelog` PR label is the only exemption. Never edit
+  CHANGELOG.md in a PR — fragments have distinct filenames precisely so
+  parallel PRs don't conflict; `scripts/changelog-release.sh <version>`
+  assembles CHANGELOG.md at release, and pushing the resulting `v*` tag
+  triggers `.github/workflows/release.yml` (verifies section + version
+  match, builds binaries, publishes the GitHub release).
 - **Tests run under `cargo nextest`** (multi-OS, stable + beta) plus doctests;
   use nextest locally to match CI.
 - **`cargo-deny`** restricts licenses to a fixed allow-list and pins sources to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,3 +19,8 @@ vocabulary; docs/agents/issue-tracker.md is the rivets tracker workflow.
   resolver events are trace-level.
 - Every push to origin/main flips open PRs to BEHIND (full CI re-cycle):
   batch tracker/doc commits locally while a merge queue is draining.
+- Changelog: every PR adds a fragment `changelog.d/<id>.<category>.md`
+  (added/changed/deprecated/removed/fixed/security; 1-5 bullets for CLI
+  users). `skip-changelog` label is the only exemption. Never edit
+  CHANGELOG.md in a PR — `scripts/changelog-release.sh <version>`
+  assembles it at release time (see changelog.d/README.md).

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,35 @@
+# changelog.d — pending release notes
+
+One fragment per PR. At release time `scripts/changelog-release.sh <version>`
+assembles every fragment here into a new `CHANGELOG.md` section and deletes
+them — between releases, this directory IS the unreleased changelog.
+
+## Format
+
+Filename: `<id>.<category>.md`
+
+- `<id>` — the rivets issue ID (e.g. `tethys-53iv`); lowercase letters,
+  digits, hyphens. Use `pr-<n>` or a short slug when there is no rivets
+  issue (dependency bumps, process changes).
+- `<category>` — one of `added`, `changed`, `deprecated`, `removed`,
+  `fixed`, `security` (the Keep a Changelog sections).
+
+Body: 1-5 markdown bullets (`- ...`); continuation lines are indented two
+spaces. Written for **users of the tethys CLI** — name commands, flags, and
+observable behavior. No rivets IDs, slice numbers, or internal module paths
+in the text: the commit log and PR body carry that story.
+
+Illustrative example (`tethys-abcd.added.md`):
+
+    - `tethys callers` accepts `--json` for machine-readable output.
+
+## Enforcement
+
+- The `changelog` CI job fails any PR that adds no fragment. The
+  `skip-changelog` PR label is the only exemption (docs/CI/chore-only PRs).
+  The label is read when the workflow event fires — after applying it,
+  re-run the check or push again.
+- `tests/changelog_lint.rs` fences the filename and body format (runs in
+  `scripts/gate.sh` and CI like any other test).
+- Never edit `CHANGELOG.md` directly in a PR — parallel PRs would conflict
+  on it; fragments have distinct filenames precisely so they never do.

--- a/changelog.d/changelog-process.added.md
+++ b/changelog.d/changelog-process.added.md
@@ -1,0 +1,3 @@
+- Releases: pushing a `v*` tag now publishes a GitHub release with prebuilt
+  Linux/macOS/Windows binaries and release notes assembled from changelog
+  fragments.

--- a/scripts/changelog-release.sh
+++ b/scripts/changelog-release.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# changelog-release.sh — assemble changelog.d/ fragments into CHANGELOG.md
+# and bump the crate version, ready for a release commit + tag.
+#
+# Usage:
+#   scripts/changelog-release.sh <version>   # e.g. scripts/changelog-release.sh 0.2.0
+#
+# What it edits (no commits, no tags — those stay in your hands):
+#   1. Cargo.toml `version` (Cargo.lock synced via cargo metadata)
+#   2. CHANGELOG.md — new `## [<version>] - <date>` section assembled from
+#      changelog.d/*.md fragments, grouped in Keep-a-Changelog category order
+#   3. changelog.d/ — consumed fragments are deleted
+#
+# Refuses to run on a dirty tree (the release commit should contain exactly
+# this script's output) or with zero fragments. Fragment shape is fenced by
+# tests/changelog_lint.rs — run scripts/gate.sh first.
+set -euo pipefail
+
+cd "$(dirname "$0")/.." || exit 2
+
+VERSION="${1:-}"
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "usage: scripts/changelog-release.sh <version>   (e.g. 0.2.0)" >&2
+  exit 2
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "❌ working tree is dirty — commit or stash first so the release" >&2
+  echo "   commit contains only the version bump + changelog assembly" >&2
+  exit 1
+fi
+
+if [[ -f CHANGELOG.md ]] && grep -q "^## \[$VERSION\]" CHANGELOG.md; then
+  echo "❌ CHANGELOG.md already has a section for $VERSION" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+
+# ── assemble the section from fragments, Keep-a-Changelog category order ──
+consumed=()
+section=""
+for cat in added changed deprecated removed fixed security; do
+  files=(changelog.d/*."$cat".md)
+  [[ ${#files[@]} -eq 0 ]] && continue
+  section+="### ${cat^}"$'\n\n'
+  for f in "${files[@]}"; do
+    section+="$(cat "$f")"$'\n'
+    consumed+=("$f")
+  done
+  section+=$'\n'
+done
+
+if [[ ${#consumed[@]} -eq 0 ]]; then
+  echo "❌ no fragments in changelog.d/ — nothing to release" >&2
+  exit 1
+fi
+
+section="## [$VERSION] - $(date +%Y-%m-%d)"$'\n\n'"$section"
+while [[ "$section" == *$'\n' ]]; do section="${section%$'\n'}"; done
+
+# ── bump Cargo.toml (first `version =` line is [package].version) ──
+sed -i "0,/^version = \".*\"/s//version = \"$VERSION\"/" Cargo.toml
+grep -q "^version = \"$VERSION\"$" Cargo.toml || {
+  echo "❌ Cargo.toml version bump failed" >&2
+  exit 1
+}
+cargo metadata --format-version 1 > /dev/null # sync Cargo.lock
+
+# ── insert the section into CHANGELOG.md (newest first, after the header) ──
+if [[ ! -f CHANGELOG.md ]]; then
+  cat > CHANGELOG.md << 'EOF'
+# Changelog
+
+All notable changes to tethys are documented here, newest release first.
+Entries are written for users of the CLI; the commit log and PR bodies
+carry the internal story.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+EOF
+fi
+
+# ENVIRON (not awk -v) so backslashes in fragment text pass through verbatim.
+SECTION="$section" awk '
+  !ins && /^## \[/ { print ENVIRON["SECTION"]; print ""; ins = 1 }
+  { print }
+  END { if (!ins) { print ""; print ENVIRON["SECTION"] } }
+' CHANGELOG.md > CHANGELOG.md.tmp
+mv CHANGELOG.md.tmp CHANGELOG.md
+
+rm "${consumed[@]}"
+
+echo "✅ assembled ${#consumed[@]} fragment(s) into CHANGELOG.md [$VERSION]"
+echo
+echo "Review the diff, then:"
+echo "  git add Cargo.toml Cargo.lock CHANGELOG.md changelog.d"
+echo "  git commit -m \"chore(release): v$VERSION\""
+echo "  git tag v$VERSION"
+echo "  git push origin main v$VERSION   # tag triggers .github/workflows/release.yml"
+echo
+echo "NOTE: the main push flips open PRs to BEHIND (full CI re-cycle) —"
+echo "release when the merge queue is empty (see CLAUDE.md)."

--- a/scripts/changelog-release.sh
+++ b/scripts/changelog-release.sh
@@ -14,6 +14,9 @@
 # Refuses to run on a dirty tree (the release commit should contain exactly
 # this script's output) or with zero fragments. Fragment shape is fenced by
 # tests/changelog_lint.rs — run scripts/gate.sh first.
+#
+# Portability: must run under macOS system bash 3.2 + BSD tools — no GNU
+# `sed -i`/`0,/re/`, no bash-4 `${var^}` (PR #22 review finding).
 set -euo pipefail
 
 cd "$(dirname "$0")/.." || exit 2
@@ -43,7 +46,8 @@ section=""
 for cat in added changed deprecated removed fixed security; do
   files=(changelog.d/*."$cat".md)
   [[ ${#files[@]} -eq 0 ]] && continue
-  section+="### ${cat^}"$'\n\n'
+  heading="$(tr '[:lower:]' '[:upper:]' <<< "${cat:0:1}")${cat:1}"
+  section+="### ${heading}"$'\n\n'
   for f in "${files[@]}"; do
     section+="$(cat "$f")"$'\n'
     consumed+=("$f")
@@ -60,7 +64,11 @@ section="## [$VERSION] - $(date +%Y-%m-%d)"$'\n\n'"$section"
 while [[ "$section" == *$'\n' ]]; do section="${section%$'\n'}"; done
 
 # ── bump Cargo.toml (first `version =` line is [package].version) ──
-sed -i "0,/^version = \".*\"/s//version = \"$VERSION\"/" Cargo.toml
+awk -v ver="$VERSION" '
+  !done && /^version = ".*"/ { $0 = "version = \"" ver "\""; done = 1 }
+  { print }
+' Cargo.toml > Cargo.toml.tmp
+mv Cargo.toml.tmp Cargo.toml
 grep -q "^version = \"$VERSION\"$" Cargo.toml || {
   echo "❌ Cargo.toml version bump failed" >&2
   exit 1

--- a/tests/changelog_lint.rs
+++ b/tests/changelog_lint.rs
@@ -1,0 +1,117 @@
+//! Format fences for `changelog.d/` release-note fragments.
+//!
+//! Every PR ships a fragment named `<slug>.<category>.md`; the `changelog`
+//! CI job enforces *presence* (only CI can see the PR diff), this test
+//! enforces *shape* — filenames parse, the category is a real
+//! Keep-a-Changelog section, and bodies stay short, bullet-only, and
+//! user-facing. `scripts/changelog-release.sh` consumes everything
+//! validated here into `CHANGELOG.md` at release time, so between releases
+//! `changelog.d/` is the unreleased changelog. See `changelog.d/README.md`
+//! for the format spec.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Keep-a-Changelog section names, lowercase, as used in fragment filenames.
+const CATEGORIES: [&str; 6] = [
+    "added",
+    "changed",
+    "deprecated",
+    "removed",
+    "fixed",
+    "security",
+];
+
+/// Fragments hold at most this many non-blank lines — they are release
+/// notes, not commit narration (the PR body carries the long story).
+const MAX_LINES: usize = 10;
+
+/// Every fragment in `changelog.d/` (everything except `README.md`),
+/// failing on anything that is not a plain file — the directory stays flat.
+fn fragment_paths() -> Vec<PathBuf> {
+    let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("changelog.d");
+    let mut paths = Vec::new();
+    for entry in fs::read_dir(&dir).expect("changelog.d/ must exist at the repo root") {
+        let path = entry.expect("readable changelog.d/ entry").path();
+        assert!(
+            path.is_file(),
+            "changelog.d/ must stay flat — unexpected non-file entry: {}",
+            path.display()
+        );
+        if path.file_name().is_some_and(|name| name == "README.md") {
+            continue;
+        }
+        paths.push(path);
+    }
+    paths
+}
+
+/// Filenames are `<slug>.<category>.md`: the slug is lowercase
+/// alphanumeric-plus-hyphen (normally the rivets issue ID, e.g.
+/// `tethys-53iv`), and the category is one of the six Keep-a-Changelog
+/// sections.
+#[test]
+fn fragment_filenames_are_slug_category_md() {
+    for path in fragment_paths() {
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("UTF-8 filename");
+        let parts: Vec<&str> = name.split('.').collect();
+        assert!(
+            parts.len() == 3 && parts[2] == "md",
+            "changelog.d/{name}: expected <slug>.<category>.md"
+        );
+        let (slug, category) = (parts[0], parts[1]);
+        let slug_ok = !slug.is_empty()
+            && !slug.starts_with('-')
+            && slug
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-');
+        assert!(
+            slug_ok,
+            "changelog.d/{name}: slug '{slug}' must be lowercase \
+             alphanumeric/hyphen (use the rivets ID, e.g. tethys-53iv)"
+        );
+        assert!(
+            CATEGORIES.contains(&category),
+            "changelog.d/{name}: category '{category}' is not one of {CATEGORIES:?}"
+        );
+    }
+}
+
+/// Bodies are 1-5 markdown bullets (`- `), each optionally continued on
+/// two-space-indented lines, and at most `MAX_LINES` non-blank lines total.
+#[test]
+fn fragment_bodies_are_short_bullet_lists() {
+    for path in fragment_paths() {
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("UTF-8 filename");
+        let body = fs::read_to_string(&path).expect("readable fragment");
+        let lines: Vec<&str> = body
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .collect();
+        assert!(!lines.is_empty(), "changelog.d/{name}: fragment is empty");
+        assert!(
+            lines.len() <= MAX_LINES,
+            "changelog.d/{name}: {} non-blank lines — fragments are short \
+             release notes; put the long story in the PR body",
+            lines.len()
+        );
+        let bullets = lines.iter().filter(|line| line.starts_with("- ")).count();
+        assert!(
+            (1..=5).contains(&bullets),
+            "changelog.d/{name}: {bullets} bullets — write 1-5 lines starting with '- '"
+        );
+        for line in &lines {
+            assert!(
+                line.starts_with("- ") || line.starts_with("  "),
+                "changelog.d/{name}: line {line:?} is neither a bullet ('- ') \
+                 nor a two-space-indented continuation"
+            );
+        }
+    }
+}

--- a/tests/changelog_lint.rs
+++ b/tests/changelog_lint.rs
@@ -26,21 +26,27 @@ const CATEGORIES: [&str; 6] = [
 /// notes, not commit narration (the PR body carries the long story).
 const MAX_LINES: usize = 10;
 
-/// Every fragment in `changelog.d/` (everything except `README.md`),
-/// failing on anything that is not a plain file — the directory stays flat.
+/// Every fragment in `changelog.d/` — everything except `README.md` and
+/// hidden entries (untracked filesystem noise like `.DS_Store` or editor
+/// swap files must not fail the fence) — failing on any other non-file
+/// entry: the directory stays flat.
 fn fragment_paths() -> Vec<PathBuf> {
     let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("changelog.d");
     let mut paths = Vec::new();
     for entry in fs::read_dir(&dir).expect("changelog.d/ must exist at the repo root") {
         let path = entry.expect("readable changelog.d/ entry").path();
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("UTF-8 filename in changelog.d/");
+        if name.starts_with('.') || name == "README.md" {
+            continue;
+        }
         assert!(
             path.is_file(),
             "changelog.d/ must stay flat — unexpected non-file entry: {}",
             path.display()
         );
-        if path.file_name().is_some_and(|name| name == "README.md") {
-            continue;
-        }
         paths.push(path);
     }
     paths


### PR DESCRIPTION
No rivets issue — process infrastructure adopted from the pi-lens project's release/changelog postmortems (entry must travel with the PR; release fails loudly on a missing section).

## What this does

Every PR now ships a release-note fragment `changelog.d/<id>.<category>.md` instead of editing a shared CHANGELOG.md. Fragments have distinct filenames so parallel sweep PRs never conflict; `scripts/changelog-release.sh <version>` assembles them into CHANGELOG.md at release time, and pushing the resulting `v*` tag triggers a release workflow that publishes binaries + notes.

- **Presence gate**: new `changelog` CI job (PR-only) fails fragment-less PRs; the `skip-changelog` label (created on the repo) is the only exemption. Wired into `ci-success` so auto-merge respects it.
- **Shape fence**: `tests/changelog_lint.rs` validates filename grammar (`<slug>.<category>.md`, six Keep-a-Changelog categories) and bullet-only bodies (1-5 bullets, two-space continuations).
- **Release path**: `release.yml` verifies tag ↔ Cargo.toml ↔ CHANGELOG agreement and zero leftover fragments BEFORE building anything, dry-runs `cargo publish --locked`, then publishes a GitHub release with Linux/macOS/Windows binaries and the extracted notes.
- **Process wiring**: ship §3 and sweep-bugs §2 write the fragment pre-PR; CLAUDE.md and AGENTS.md carry the rule.

## Acceptance criteria

- [x] Fragment-less PRs fail CI — `changelog` job, exempt only via `skip-changelog` label
- [x] Malformed fragments fail the test suite — `changelog_lint::fragment_filenames_are_slug_category_md`, `changelog_lint::fragment_bodies_are_short_bullet_lists`
- [x] Release refuses missing/empty notes — `release.yml` verify job (section grep + leftover-fragment check + non-blank extracted notes)
- [x] Parallel PRs cannot conflict on release notes — one distinct file per PR, CHANGELOG.md untouched until release

## Method + evidence

- TDD-inversion on the fences: a bad category and a non-bullet body each turn the suite red; clean state passes (2/2).
- `changelog-release.sh` exercised end-to-end in a scratch crate: fresh CHANGELOG creation, category grouping in Keep-a-Changelog order, second release inserting above the first, continuation lines preserved, refusal on dirty tree / duplicate section / zero fragments.
- Gates: fmt clean, clippy pedantic `-D warnings` clean, both workflow files YAML-validated.
- This PR satisfies its own gate: `changelog.d/changelog-process.added.md` rides along.

## Notable behavior changes

- The gate takes effect for every PR opened after this merges; there are currently no open PRs to strand.
- First release using the new path: run `scripts/changelog-release.sh <version>` on a clean main, review, commit `chore(release): v<version>`, tag, push — release when the merge queue is empty (main push flips open PRs to BEHIND).