### PR TITLE
docs(context): add query-standing term and doc-maintenance rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,3 +207,11 @@ Single-context layout at the repo root: `CONTEXT.md` (the domain glossary) plus
 `docs/adr/` (architectural decision records; ADR-0001 is the `ModuleResolver` seam,
 ADR-0002 is SQL-CTEs-not-petgraph, ADR-0003 is resolution provenance — store the
 strategy, derive the band). See `docs/agents/domain.md`.
+
+#### Doc maintenance
+
+Update AGENTS.md and CONTEXT.md in the **same commit** as the change that alters
+what they describe — never as a follow-up. A stale claim is worse than none:
+agents act on it as fact. When recording a hard-won lesson, cite the rivets ID
+or PR that taught it. (Adopted 2026-07-12 from the pi-lens project's AGENTS.md
+rule #1.)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -197,3 +197,15 @@ A symbol-to-symbol call relationship retained in the index. Cross-crate edges ar
 kept only when corroborated by an import ("k-hybrid"); a raw call reference is the
 pre-corroboration signal, a call edge is the retained fact.
 _Avoid_: call, call reference (when you mean the retained edge)
+
+### Query standing
+
+**Confirmed / Indeterminate (query standing)**:
+Whether the index can stand behind an analysis result as a whole. A result is
+*confirmed* when every input file is indexed and fresh; *indeterminate* when an
+input is missing from the index or stale on disk. An indeterminate empty result
+means "cannot see", never "clean" — it must surface distinguishably, not as
+silence.
+_Avoid_: treating an empty result as clean without checking standing; conflating
+standing with confidence bands (bands grade individual edges; standing grades a
+query's inputs).


### PR DESCRIPTION
Docs-only output of the 2026-07-12 grill session on the remaining pi-lens takeaways (carries the `skip-changelog` label — no CLI-visible behavior).

- **CONTEXT.md**: new *Query standing* term — `confirmed` / `indeterminate` — with an avoid-line keeping it distinct from confidence bands. Vocabulary lands ahead of tethys-09wx (affected-tests exit-2 contract) so the implementation inherits settled language.
- **AGENTS.md**: new *Doc maintenance* rule under Custom Instructions — update AGENTS.md/CONTEXT.md in the same commit that changes what they describe, and cite the rivets ID/PR that taught each lesson.

Session's tracker output (already on main via `chore(rivets)`): filed tethys-09wx, tethys-r4j2, tethys-m1rz, tethys-xpc4; widened tethys-a3xc; amended tethys-o4re with the adapter-seam AC.