### PR TITLE
fix(indexing): purge orphan files before dependency pass (tethys-dhxo)

### DIFF
--- a/changelog.d/tethys-dhxo.fixed.md
+++ b/changelog.d/tethys-dhxo.fixed.md
@@ -1,0 +1,6 @@
+- `tethys index` now removes deleted files from the index: rows for source
+  files deleted from disk since the last index are purged instead of
+  lingering forever.
+- Streaming-mode indexing no longer resurrects dependency edges from deleted
+  files, so `coupling`, `callers`, `cycles`, and `impact` results no longer
+  include phantom contributions from files that no longer exist.

--- a/src/db/files.rs
+++ b/src/db/files.rs
@@ -419,6 +419,36 @@ impl Index {
         Ok(files)
     }
 
+    /// Delete file rows by ID in one transaction, returning how many rows
+    /// were deleted.
+    ///
+    /// Foreign-key cascades (`PRAGMA foreign_keys` is ON from
+    /// [`Self::open`]) remove every dependent row: `symbols`, `refs`,
+    /// `imports`, `file_deps` (both directions), and `arch_file_packages`
+    /// cascade from `files` directly; `attributes` and `call_edges` cascade
+    /// via the deleted `symbols`. Refs in OTHER files that resolved to a
+    /// deleted file's symbols are cascade-deleted too (`refs.symbol_id`),
+    /// which is correct: their target symbol no longer exists.
+    ///
+    /// Used by the orphan-cleanup pass (`Tethys::purge_orphan_files`) to
+    /// drop files that were deleted from disk since their last index.
+    pub fn delete_files(&mut self, ids: &[FileId]) -> Result<usize> {
+        if ids.is_empty() {
+            return Ok(0);
+        }
+        let mut conn = self.connection()?;
+        let tx = conn.transaction()?;
+        let mut deleted = 0;
+        {
+            let mut stmt = tx.prepare_cached("DELETE FROM files WHERE id = ?1")?;
+            for id in ids {
+                deleted += stmt.execute([id.as_i64()])?;
+            }
+        }
+        tx.commit()?;
+        Ok(deleted)
+    }
+
     /// Get all indexed files.
     ///
     /// Used for dependency computation after streaming writes.
@@ -857,6 +887,156 @@ mod list_all_files_tests {
         let (_dir, index) = temp_index();
         let files = index.list_all_files().expect("list_all_files");
         assert!(files.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod delete_files_tests {
+    use crate::db::Index;
+    use crate::types::{FileId, Language};
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn temp_index() -> (TempDir, Index) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let index = Index::open(&dir.path().join("idx.db")).expect("open index");
+        (dir, index)
+    }
+
+    /// Two files with the full spread of dependent rows: symbols (with an
+    /// attribute), refs (own-file and cross-file resolved), imports,
+    /// `file_deps` in both directions, and a `call_edges` row between the
+    /// two files' symbols.
+    fn seed_two_file_fixture(index: &Index) -> (FileId, FileId) {
+        let conn = index.connection().expect("conn");
+        conn.execute_batch(
+            "INSERT INTO files (id, path, language, mtime_ns, size_bytes, indexed_at) VALUES
+                 (1, 'gone.rs', 'rust', 0, 0, 0),
+                 (2, 'kept.rs', 'rust', 0, 0, 0);
+             INSERT INTO symbols (id, file_id, name, module_path, qualified_name,
+                                  kind, line, column, visibility) VALUES
+                 (10, 1, 'gone_fn', '', 'gone_fn', 'function', 1, 1, 'pub'),
+                 (20, 2, 'kept_fn', '', 'kept_fn', 'function', 1, 1, 'pub');
+             INSERT INTO attributes (symbol_id, name, args, line)
+                 VALUES (10, 'derive', 'Clone', 1);
+             -- gone.rs ref resolved to kept.rs's symbol; kept.rs ref resolved
+             -- to gone.rs's symbol (must cascade via refs.symbol_id).
+             INSERT INTO refs (id, symbol_id, file_id, kind, line, column, in_symbol_id) VALUES
+                 (100, 20, 1, 'call', 2, 1, 10),
+                 (200, 10, 2, 'call', 2, 1, 20);
+             INSERT INTO imports (file_id, symbol_name, source_module) VALUES
+                 (1, 'kept_fn', 'crate::kept'),
+                 (2, 'gone_fn', 'crate::gone');
+             INSERT INTO file_deps (from_file_id, to_file_id, ref_count) VALUES
+                 (1, 2, 1),
+                 (2, 1, 1);
+             INSERT INTO call_edges (caller_symbol_id, callee_symbol_id) VALUES
+                 (10, 20),
+                 (20, 10);",
+        )
+        .expect("seed fixture");
+        (FileId::from(1), FileId::from(2))
+    }
+
+    fn table_count(index: &Index, sql: &str) -> i64 {
+        index
+            .connection()
+            .expect("conn")
+            .query_row(sql, [], |row| row.get(0))
+            .expect("count")
+    }
+
+    /// Deleting a file cascades to EVERY dependent table — `symbols`,
+    /// `attributes`, `refs` (own rows AND other files' rows resolved to the
+    /// deleted file's symbols), `imports`, `file_deps` in both directions,
+    /// and `call_edges` via the deleted symbols.
+    #[test]
+    fn delete_files_cascades_to_all_dependent_tables() {
+        let (_dir, mut index) = temp_index();
+        let (gone, _kept) = seed_two_file_fixture(&index);
+
+        let deleted = index.delete_files(&[gone]).expect("delete");
+        assert_eq!(deleted, 1, "exactly one file row deleted");
+
+        for (expected, sql) in [
+            (1, "SELECT COUNT(*) FROM files"),
+            (1, "SELECT COUNT(*) FROM symbols"),
+            (0, "SELECT COUNT(*) FROM attributes"),
+            // Both refs cascade: one by file_id, one by symbol_id.
+            (0, "SELECT COUNT(*) FROM refs"),
+            (1, "SELECT COUNT(*) FROM imports"),
+            (0, "SELECT COUNT(*) FROM file_deps"),
+            (0, "SELECT COUNT(*) FROM call_edges"),
+        ] {
+            let count = table_count(&index, sql);
+            assert_eq!(count, expected, "after delete: {sql} -> {count}");
+        }
+
+        // The surviving rows all belong to kept.rs.
+        let conn = index.connection().expect("conn");
+        let kept_path: String = conn
+            .query_row("SELECT path FROM files", [], |row| row.get(0))
+            .expect("surviving file");
+        assert_eq!(kept_path, "kept.rs");
+    }
+
+    /// Deleting several files in one call works and reports the total.
+    #[test]
+    fn delete_files_removes_multiple_ids() {
+        let (_dir, mut index) = temp_index();
+        let (gone, kept) = seed_two_file_fixture(&index);
+
+        let deleted = index.delete_files(&[gone, kept]).expect("delete");
+        assert_eq!(deleted, 2);
+        assert_eq!(table_count(&index, "SELECT COUNT(*) FROM files"), 0);
+        assert_eq!(table_count(&index, "SELECT COUNT(*) FROM symbols"), 0);
+    }
+
+    /// Empty input is a no-op; unknown IDs delete nothing and don't error.
+    #[test]
+    fn delete_files_handles_empty_and_unknown_ids() {
+        let (_dir, mut index) = temp_index();
+        index
+            .upsert_file(Path::new("a.rs"), Language::Rust, 0, 0, None)
+            .expect("insert file");
+
+        assert_eq!(index.delete_files(&[]).expect("empty"), 0);
+        assert_eq!(
+            index
+                .delete_files(&[FileId::from(999_999)])
+                .expect("unknown id"),
+            0
+        );
+        assert_eq!(table_count(&index, "SELECT COUNT(*) FROM files"), 1);
+    }
+
+    /// The whole purge is one transaction: exactly one commit regardless of
+    /// how many IDs are deleted.
+    #[test]
+    fn delete_files_commits_once() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let (_dir, mut index) = temp_index();
+        let (gone, kept) = seed_two_file_fixture(&index);
+
+        let commits = Arc::new(AtomicUsize::new(0));
+        {
+            let counter = Arc::clone(&commits);
+            let conn = index.connection().expect("conn");
+            conn.commit_hook(Some(move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                false
+            }));
+        }
+
+        index.delete_files(&[gone, kept]).expect("delete");
+
+        index
+            .connection()
+            .expect("conn")
+            .commit_hook(None::<fn() -> bool>);
+        assert_eq!(commits.load(Ordering::SeqCst), 1);
     }
 }
 

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -191,6 +191,21 @@ impl Tethys {
         let total_files = source_files.len();
         let workspace_root = self.workspace_root.clone();
 
+        // Orphan-cleanup pass (tethys-dhxo): purge rows for files deleted
+        // from disk since their last index BEFORE any write/dependency pass.
+        // Nothing else ever deletes them — the files-table DELETE logic only
+        // fires when an existing file is re-indexed — and streaming mode's
+        // `compute_all_dependencies` walks every DB file, so a surviving
+        // orphan re-inserts `file_deps` edges from its stale stored imports
+        // and refs. FK cascades take the orphan's dependent rows with it.
+        let purged_orphans = self.purge_orphan_files(&source_files)?;
+        if purged_orphans > 0 {
+            info!(
+                purged_orphans,
+                "Removed index rows for files deleted from disk"
+            );
+        }
+
         // Clear file_deps before per-file dependency computation so stale rows
         // from prior runs don't accumulate via the UPSERT in
         // `insert_file_dependency`. Mirrors `clear_all_call_edges` at the

--- a/src/reindex.rs
+++ b/src/reindex.rs
@@ -3,7 +3,7 @@
 //! Thin wrappers around the core indexing pipeline for incremental updates
 //! and full rebuilds.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
@@ -12,7 +12,7 @@ use tracing::{debug, warn};
 use crate::Tethys;
 use crate::db::normalize_path;
 use crate::error::Result;
-use crate::types::{IndexOptions, IndexStats, IndexUpdate, StalenessReport};
+use crate::types::{FileId, IndexOptions, IndexStats, IndexUpdate, Language, StalenessReport};
 
 /// Classification of a single file's state relative to its indexed entry.
 ///
@@ -172,6 +172,58 @@ impl Tethys {
     fn lookup_key(&self, file_path: &Path) -> String {
         let relative = self.relative_path(file_path);
         normalize_path(relative.as_ref())
+    }
+
+    /// Purge index rows for orphan files: files still in the DB whose disk
+    /// counterpart was deleted since their last index.
+    ///
+    /// `disk_files` is the just-discovered source-file set (absolute paths),
+    /// so no second workspace walk is needed. A DB file missing from that
+    /// set is only a CANDIDATE: the purge re-checks the filesystem via
+    /// [`classify_indexed_file`] and deletes the row only on
+    /// [`FileChange::Deleted`] — a file the walk skipped for other reasons
+    /// (e.g. an unreadable directory) still exists on disk and is left
+    /// alone. FK cascades remove the orphan's dependent rows (see
+    /// [`crate::db::Index::delete_files`]).
+    ///
+    /// Runs from `index_with_options` BEFORE the dependency/resolution
+    /// passes: without it, streaming mode's `compute_all_dependencies`
+    /// iterates every DB file — orphans included — and re-inserts
+    /// `file_deps` edges from the orphan's stale stored imports and refs,
+    /// feeding phantom contributions to coupling, callers, cycles, and
+    /// impact queries.
+    ///
+    /// Returns the number of purged file rows.
+    pub(crate) fn purge_orphan_files(
+        &mut self,
+        disk_files: &[(PathBuf, Language)],
+    ) -> Result<usize> {
+        let disk_keys: HashSet<String> = disk_files
+            .iter()
+            .map(|(path, _)| self.lookup_key(path))
+            .collect();
+
+        let orphan_ids: Vec<FileId> = self
+            .db
+            .list_all_files()?
+            .into_iter()
+            .filter(|f| !disk_keys.contains(&normalize_path(&f.path)))
+            .filter(|f| {
+                let abs = self.workspace_root.join(&f.path);
+                classify_indexed_file(&abs, f.mtime_ns, f.size_bytes) == FileChange::Deleted
+            })
+            .map(|f| f.id)
+            .collect();
+
+        if orphan_ids.is_empty() {
+            return Ok(0);
+        }
+        let purged = self.db.delete_files(&orphan_ids)?;
+        debug!(
+            purged,
+            "Purged orphan file rows (files deleted from disk since last index)"
+        );
+        Ok(purged)
     }
 
     /// Rebuild the entire index from scratch.

--- a/tests/orphan_files.rs
+++ b/tests/orphan_files.rs
@@ -1,0 +1,257 @@
+//! Regression tests for orphan files: rows for files deleted from disk that
+//! survive in the DB across re-index runs.
+//!
+//! Pre-fix, `index_with_options` had no orphan-cleanup pass: the `files`-table
+//! DELETE logic only fired when an existing file was re-indexed, so a file
+//! deleted from disk kept its `files`/`symbols`/`refs`/`imports` rows forever.
+//! Streaming mode (`IndexOptions::with_streaming()`) then computed file-level
+//! dependencies from STORED data for every file in the DB — including orphans
+//! — re-inserting `file_deps` rows with the orphan as `from_file_id`.
+//! Downstream queries (coupling, callers, cycles, impact) saw the orphan as a
+//! real source of cross-file edges.
+//!
+//! Post-fix, an orphan-cleanup pass purges deleted-from-disk file rows before
+//! any dependency computation, and FK cascades remove the dependent rows.
+//!
+//! Both batch (`IndexOptions::default()`) and streaming (`with_streaming()`)
+//! modes are exercised: pre-fix only streaming re-inserted orphan `file_deps`,
+//! but the orphan rows themselves lingered in both modes.
+
+use rstest::rstest;
+use std::fs;
+use tempfile::TempDir;
+use tethys::{IndexOptions, Tethys};
+
+/// Workspace-relative path of the file the tests delete from disk.
+const ORPHAN_PATH: &str = "crate_caller/src/lib.rs";
+
+/// Create a 2-crate workspace with a cross-crate dependency that keeps an
+/// UNRESOLVED reference in the DB.
+///
+/// `crate_caller` imports `crate_target::Widget` (resolves in Pass 2) and
+/// `crate_target::generated_helper` — a function produced by a
+/// `macro_rules!` expansion, which tree-sitter extraction never sees as a
+/// symbol. The `generated_helper()` call therefore stays unresolved with its
+/// `reference_name` intact across runs. That surviving name is what
+/// corroborates the stored import when streaming mode recomputes dependencies
+/// from stored data, so the orphan re-inserts a `file_deps` edge pre-fix.
+/// (Resolved refs can't reproduce this: resolution nulls `reference_name`,
+/// and rewriting the target file cascade-deletes refs bound to its symbols.)
+fn build_workspace_with_unresolved_cross_crate_ref(dir: &TempDir) {
+    let files: [(&str, &str); 5] = [
+        (
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"crate_caller\", \"crate_target\"]\nresolver = \"2\"\n",
+        ),
+        (
+            "crate_caller/Cargo.toml",
+            "[package]\nname = \"crate_caller\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\
+             [dependencies]\ncrate_target = { path = \"../crate_target\" }\n",
+        ),
+        (
+            "crate_caller/src/lib.rs",
+            "use crate_target::Widget;\n\
+             use crate_target::generated_helper;\n\n\
+             pub fn make_and_call() {\n\
+                 let _w = Widget;\n\
+                 generated_helper();\n\
+             }\n",
+        ),
+        (
+            "crate_target/Cargo.toml",
+            "[package]\nname = \"crate_target\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        ),
+        (
+            "crate_target/src/lib.rs",
+            "pub struct Widget;\n\n\
+             macro_rules! gen_helper {\n\
+                 () => {\n\
+                     pub fn generated_helper() {}\n\
+                 };\n\
+             }\n\
+             gen_helper!();\n",
+        ),
+    ];
+    for (rel, content) in files {
+        let full = dir.path().join(rel);
+        fs::create_dir_all(full.parent().expect("relative path has parent"))
+            .expect("create parent");
+        fs::write(&full, content).expect("write file");
+    }
+}
+
+fn open_readonly(db_path: &std::path::Path) -> rusqlite::Connection {
+    rusqlite::Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .expect("open tethys.db read-only")
+}
+
+/// Look up the `files.id` for a workspace-relative path, if the row exists.
+fn file_id_for(conn: &rusqlite::Connection, path: &str) -> Option<i64> {
+    conn.query_row("SELECT id FROM files WHERE path = ?1", [path], |row| {
+        row.get(0)
+    })
+    .map_or_else(
+        |e| match e {
+            rusqlite::Error::QueryReturnedNoRows => None,
+            other => panic!("files lookup failed: {other}"),
+        },
+        Some,
+    )
+}
+
+fn count(conn: &rusqlite::Connection, sql: &str, id: i64) -> i64 {
+    conn.query_row(sql, [id], |row| row.get(0))
+        .expect("count query")
+}
+
+/// Deleting a source file from disk and re-indexing (non-rebuild) must not
+/// leave `file_deps` rows originating from the deleted file.
+///
+/// Pre-fix this failed in streaming mode: `compute_all_dependencies` iterated
+/// every file in the DB, loaded the orphan's stale stored imports + refs, and
+/// re-inserted the orphan's outgoing edge — a phantom contribution to
+/// coupling (Ce), cycles, and impact analysis.
+#[rstest]
+#[case::batch(IndexOptions::default)]
+#[case::streaming(IndexOptions::with_streaming)]
+fn reindex_after_disk_delete_leaves_no_file_deps_from_orphan(
+    #[case] options_factory: fn() -> IndexOptions,
+) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    build_workspace_with_unresolved_cross_crate_ref(&dir);
+    let mut tethys = Tethys::new(dir.path()).expect("Tethys::new");
+
+    tethys
+        .index_with_options(options_factory())
+        .expect("first index");
+    let db_path = tethys.db_path().to_path_buf();
+
+    let orphan_id = {
+        let conn = open_readonly(&db_path);
+        let orphan_id = file_id_for(&conn, ORPHAN_PATH).expect("caller file indexed by run 1");
+        // Vacuousness guard: run 1 must record the caller's outgoing edge,
+        // otherwise the post-delete assertion below can't catch anything.
+        let outgoing = count(
+            &conn,
+            "SELECT COUNT(*) FROM file_deps WHERE from_file_id = ?1",
+            orphan_id,
+        );
+        assert!(
+            outgoing >= 1,
+            "fixture must produce >=1 outgoing file_deps edge from {ORPHAN_PATH} \
+             after the first index; got {outgoing}"
+        );
+        orphan_id
+    };
+
+    fs::remove_file(dir.path().join(ORPHAN_PATH)).expect("delete caller source from disk");
+
+    tethys
+        .index_with_options(options_factory())
+        .expect("second index");
+
+    let conn = open_readonly(&db_path);
+    let phantom_edges = count(
+        &conn,
+        "SELECT COUNT(*) FROM file_deps WHERE from_file_id = ?1",
+        orphan_id,
+    );
+    assert_eq!(
+        phantom_edges, 0,
+        "no file_deps row may originate from a file deleted from disk; \
+         found {phantom_edges} edge(s) from orphan {ORPHAN_PATH} after re-index"
+    );
+}
+
+/// Re-indexing after a disk delete must purge the orphan's `files` row, and
+/// FK cascades must remove its dependent `symbols`, `refs`, and `imports`
+/// rows — so no downstream query can see the orphan at all.
+#[rstest]
+#[case::batch(IndexOptions::default)]
+#[case::streaming(IndexOptions::with_streaming)]
+fn reindex_after_disk_delete_purges_orphan_rows(#[case] options_factory: fn() -> IndexOptions) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    build_workspace_with_unresolved_cross_crate_ref(&dir);
+    let mut tethys = Tethys::new(dir.path()).expect("Tethys::new");
+
+    tethys
+        .index_with_options(options_factory())
+        .expect("first index");
+    let db_path = tethys.db_path().to_path_buf();
+
+    let orphan_id = {
+        let conn = open_readonly(&db_path);
+        let orphan_id = file_id_for(&conn, ORPHAN_PATH).expect("caller file indexed by run 1");
+        // Vacuousness guard: the orphan must actually have dependent rows.
+        for (table, sql) in [
+            ("symbols", "SELECT COUNT(*) FROM symbols WHERE file_id = ?1"),
+            ("imports", "SELECT COUNT(*) FROM imports WHERE file_id = ?1"),
+        ] {
+            let rows = count(&conn, sql, orphan_id);
+            assert!(
+                rows >= 1,
+                "fixture must produce >=1 {table} row for {ORPHAN_PATH} after run 1; got {rows}"
+            );
+        }
+        orphan_id
+    };
+
+    fs::remove_file(dir.path().join(ORPHAN_PATH)).expect("delete caller source from disk");
+
+    tethys
+        .index_with_options(options_factory())
+        .expect("second index");
+
+    let conn = open_readonly(&db_path);
+    assert_eq!(
+        file_id_for(&conn, ORPHAN_PATH),
+        None,
+        "the files row for a deleted-from-disk file must be purged on re-index"
+    );
+    for (table, sql) in [
+        ("symbols", "SELECT COUNT(*) FROM symbols WHERE file_id = ?1"),
+        ("refs", "SELECT COUNT(*) FROM refs WHERE file_id = ?1"),
+        ("imports", "SELECT COUNT(*) FROM imports WHERE file_id = ?1"),
+    ] {
+        let leftover = count(&conn, sql, orphan_id);
+        assert_eq!(
+            leftover, 0,
+            "orphan purge must cascade to {table}; found {leftover} row(s) \
+             still referencing the deleted file"
+        );
+    }
+}
+
+/// A file that still exists on disk must never be purged as an orphan —
+/// re-indexing an unchanged workspace keeps every file row.
+///
+/// Guards against an over-eager cleanup (e.g. purging files the directory
+/// walk skipped, or comparing paths in mismatched forms).
+#[rstest]
+#[case::batch(IndexOptions::default)]
+#[case::streaming(IndexOptions::with_streaming)]
+fn reindex_without_deletion_keeps_all_file_rows(#[case] options_factory: fn() -> IndexOptions) {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    build_workspace_with_unresolved_cross_crate_ref(&dir);
+    let mut tethys = Tethys::new(dir.path()).expect("Tethys::new");
+
+    tethys
+        .index_with_options(options_factory())
+        .expect("first index");
+    let db_path = tethys.db_path().to_path_buf();
+    let before: i64 = open_readonly(&db_path)
+        .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
+        .expect("count files");
+
+    tethys
+        .index_with_options(options_factory())
+        .expect("second index");
+
+    let after: i64 = open_readonly(&db_path)
+        .query_row("SELECT COUNT(*) FROM files", [], |row| row.get(0))
+        .expect("count files");
+    assert_eq!(
+        before, after,
+        "re-indexing an unchanged workspace must not purge live file rows"
+    );
+}


### PR DESCRIPTION
Fixes the tethys-dhxo bug class: orphan files (deleted from disk but still in the DB) contributing phantom `file_deps` edges on streaming re-index.

## Repro

New fence `tests/orphan_files.rs`, written red-first against `fd100a9`:

- `reindex_after_disk_delete_leaves_no_file_deps_from_orphan` — two-crate workspace, streaming index, delete `crate_caller/src/lib.rs` from disk, streaming re-index (non-rebuild). **Pre-fix: 1 phantom `file_deps` edge re-inserted with the orphan as `from_file_id` (streaming case failed; batch case passed — exactly the asymmetry filed in the issue).**
- `reindex_after_disk_delete_purges_orphan_rows` — pre-fix the orphan's `files`/`symbols`/`refs`/`imports` rows lingered in **both** modes.

Repro subtlety worth recording: resolution nulls `reference_name`, and rewriting a target file cascade-deletes the orphan's refs bound to its symbols — so resolved refs cannot corroborate the orphan's stored imports on the next run. The reproducing (and realistic) shape is a ref that stays **unresolved with its name intact**: the fixture calls a function generated by a `macro_rules!` expansion in the target crate, which tree-sitter extraction never sees as a symbol.

## Cause

`index_with_options` has no orphan-cleanup pass: the `files`-table DELETE logic only fires when an existing on-disk file is re-indexed, so nothing ever removes rows for files deleted from disk. Streaming mode's `compute_all_dependencies` iterates `list_all_files()` — orphans included — loads their stale stored imports + refs, and `compute_dependencies_from_stored` re-inserts `file_deps` rows from the orphan. Coupling (Ce/Ca), callers, cycles, and impact then see the orphan as a real edge source.

## Fix

The adjudicated shape (option 1): a new orphan-cleanup pass, run from `index_with_options` before any write/dependency pass.

- `Tethys::purge_orphan_files` (`src/reindex.rs`, beside the staleness machinery it reuses): candidates are DB files missing from the just-discovered source set; each is confirmed via `classify_indexed_file` returning `FileChange::Deleted`, so a file the walk skipped for any other reason (e.g. unreadable directory) is left alone.
- `Index::delete_files` (`src/db/files.rs`): deletes the file rows in one transaction; FK cascades remove the dependents.

**Cascade audit (all covered, no explicit child deletes needed):** `symbols`, `refs` (by `file_id`, and other files' refs bound to the orphan's symbols by `symbol_id`), `imports`, `file_deps` (both directions), `arch_file_packages` cascade from `files` directly; `attributes` and `call_edges` cascade via `symbols`. `arch_package_deps` has no FK from `files` but is fully rebuilt by the architecture phase each run, which executes after the purge. `PRAGMA foreign_keys=ON` is set in `Index::open`. The unit test `delete_files_cascades_to_all_dependent_tables` pins this table-by-table.

Callers of the changed entry point (`index()`, `update()`, `rebuild_with_options`, `cli/index.rs`) are unchanged in signature; `--rebuild` resets the DB first so the purge is a no-op there.

## Fence

- `tests/orphan_files.rs`: `reindex_after_disk_delete_leaves_no_file_deps_from_orphan`, `reindex_after_disk_delete_purges_orphan_rows`, `reindex_without_deletion_keeps_all_file_rows` (over-eager-purge guard) — each parameterized batch + streaming.
- `src/db/files.rs::delete_files_tests`: cascade coverage, multi-id, empty/unknown-id no-op, single-commit transaction.

Gates: `cargo nextest run`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test --doc` — all OK with real exit codes.

Changelog fragment: `changelog.d/tethys-dhxo.fixed.md`.