### PR TITLE
fix(lsp): negotiate position encoding and convert utf-16 columns (tethys-2d1x)

### DIFF
--- a/changelog.d/tethys-2d1x.fixed.md
+++ b/changelog.d/tethys-2d1x.fixed.md
@@ -1,0 +1,4 @@
+- `tethys index --lsp` and `tethys callers --lsp` now negotiate the LSP
+  position encoding, so references on lines containing non-ASCII text
+  (CJK strings, em-dashes, emoji) resolve to the right symbol instead of
+  missing or hitting the wrong one.

--- a/src/lsp/encoding.rs
+++ b/src/lsp/encoding.rs
@@ -1,0 +1,171 @@
+//! LSP position encoding negotiation and column conversion.
+//!
+//! Tethys stores tree-sitter columns, which are BYTE offsets into the line
+//! (`utf-8` code units). LSP positions default to `utf-16` code units unless
+//! a different encoding is negotiated during `initialize` (LSP 3.17
+//! `general.positionEncodings`). Tethys advertises `utf-8` first — a server
+//! that accepts it (rust-analyzer does) makes conversion an identity no-op —
+//! and re-measures outgoing columns when the server insists on `utf-16`.
+//!
+//! Only OUTGOING positions are converted. Incoming ranges are matched back
+//! line-granularly (`find_symbol_at_line`), and line numbers are identical
+//! in every position encoding, so no inverse conversion is needed today.
+
+use lsp_types::{InitializeResult, PositionEncodingKind};
+use tracing::trace;
+
+/// Position encoding negotiated with an LSP server during `initialize`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PositionEncoding {
+    /// Byte offsets — identity for tethys's stored tree-sitter columns.
+    Utf8,
+    /// `utf-16` code units — the LSP spec default; requires conversion.
+    Utf16,
+}
+
+impl PositionEncoding {
+    /// Read the server's chosen encoding from the `initialize` result.
+    ///
+    /// Falls back to `Utf16` when the server reports none (the LSP spec
+    /// default) or reports an encoding tethys doesn't advertise.
+    pub(crate) fn from_initialize_result(result: &InitializeResult) -> Self {
+        match result.capabilities.position_encoding.as_ref() {
+            Some(kind) if *kind == PositionEncodingKind::UTF8 => Self::Utf8,
+            _ => Self::Utf16,
+        }
+    }
+
+    /// Convert a 0-indexed BYTE column on `line_text` into this encoding.
+    ///
+    /// `Utf8` is an identity no-op. For `Utf16` the byte prefix of the line
+    /// is re-measured as `utf-16` code units. A `byte_col` that is out of
+    /// range or not on a char boundary falls back to the raw byte offset
+    /// rather than dropping the request (correct for ASCII-only prefixes,
+    /// best-effort otherwise).
+    pub(crate) fn col_from_utf8(self, line_text: &str, byte_col: u32) -> u32 {
+        if self == Self::Utf8 {
+            return byte_col;
+        }
+        let prefix = usize::try_from(byte_col)
+            .ok()
+            .and_then(|col| line_text.get(..col));
+        if let Some(prefix) = prefix {
+            u32::try_from(prefix.encode_utf16().count()).unwrap_or(byte_col)
+        } else {
+            trace!(
+                byte_col,
+                line_len = line_text.len(),
+                "byte column out of range or mid-character; sending raw offset"
+            );
+            byte_col
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lsp_types::ServerCapabilities;
+
+    fn initialize_result(encoding: Option<PositionEncodingKind>) -> InitializeResult {
+        InitializeResult {
+            capabilities: ServerCapabilities {
+                position_encoding: encoding,
+                ..Default::default()
+            },
+            server_info: None,
+        }
+    }
+
+    /// A server that accepts the advertised `utf-8` makes conversion identity.
+    #[test]
+    fn negotiation_picks_utf8_when_server_chooses_it() {
+        let result = initialize_result(Some(PositionEncodingKind::UTF8));
+        assert_eq!(
+            PositionEncoding::from_initialize_result(&result),
+            PositionEncoding::Utf8
+        );
+    }
+
+    /// No reported encoding means the LSP spec default: `utf-16`.
+    #[test]
+    fn negotiation_defaults_to_utf16_when_absent() {
+        let result = initialize_result(None);
+        assert_eq!(
+            PositionEncoding::from_initialize_result(&result),
+            PositionEncoding::Utf16
+        );
+    }
+
+    /// An unadvertised encoding (e.g. `utf-32`) falls back to `utf-16`.
+    #[test]
+    fn negotiation_falls_back_to_utf16_for_unadvertised_kind() {
+        let result = initialize_result(Some(PositionEncodingKind::UTF32));
+        assert_eq!(
+            PositionEncoding::from_initialize_result(&result),
+            PositionEncoding::Utf16
+        );
+
+        let result = initialize_result(Some(PositionEncodingKind::UTF16));
+        assert_eq!(
+            PositionEncoding::from_initialize_result(&result),
+            PositionEncoding::Utf16
+        );
+    }
+
+    /// ASCII-only prefix: byte and `utf-16` columns coincide (identity).
+    #[test]
+    fn utf16_col_is_identity_for_ascii_line() {
+        let line = "    let x = compute();";
+        assert_eq!(PositionEncoding::Utf16.col_from_utf8(line, 12), 12);
+    }
+
+    /// Multibyte text BEFORE the column shrinks it: each CJK char is 3
+    /// `utf-8` bytes but 1 `utf-16` unit.
+    #[test]
+    fn utf16_col_shrinks_after_multibyte_prefix() {
+        // "日本語" = 9 bytes, 3 utf-16 units; the identifier starts after
+        // `let s = "日本語"; ` → byte 21, utf-16 unit 15.
+        let line = "let s = \"\u{65e5}\u{672c}\u{8a9e}\"; foo()";
+        let byte_col = u32::try_from(line.find("foo").expect("foo present")).expect("fits");
+        assert_eq!(byte_col, 21, "fixture self-check: byte offset of foo");
+        assert_eq!(PositionEncoding::Utf16.col_from_utf8(line, byte_col), 15);
+    }
+
+    /// Multibyte text AFTER the column does not affect it (identity).
+    #[test]
+    fn utf16_col_ignores_multibyte_after_column() {
+        let line = "foo(); // \u{65e5}\u{672c}\u{8a9e}";
+        assert_eq!(PositionEncoding::Utf16.col_from_utf8(line, 0), 0);
+        assert_eq!(PositionEncoding::Utf16.col_from_utf8(line, 3), 3);
+    }
+
+    /// Emoji are surrogate pairs: 4 `utf-8` bytes = 2 `utf-16` units.
+    #[test]
+    fn utf16_col_counts_surrogate_pairs_for_emoji() {
+        // "😀" (U+1F600) = 4 bytes, 2 utf-16 units.
+        let line = "\"\u{1f600}\" bar()";
+        let byte_col = u32::try_from(line.find("bar").expect("bar present")).expect("fits");
+        assert_eq!(byte_col, 7, "fixture self-check: byte offset of bar");
+        // quote(1) + emoji(2) + quote(1) + space(1) = 5 utf-16 units.
+        assert_eq!(PositionEncoding::Utf16.col_from_utf8(line, byte_col), 5);
+    }
+
+    /// `utf-8` negotiation is an identity no-op even with multibyte text.
+    #[test]
+    fn utf8_col_is_identity_even_with_multibyte_prefix() {
+        let line = "let s = \"\u{65e5}\u{672c}\u{8a9e}\"; foo()";
+        assert_eq!(PositionEncoding::Utf8.col_from_utf8(line, 20), 20);
+    }
+
+    /// Out-of-range and mid-character byte columns fall back to the raw
+    /// offset rather than panicking or dropping the request.
+    #[test]
+    fn utf16_col_falls_back_to_raw_offset_when_unsliceable() {
+        let line = "\u{65e5}\u{672c}";
+        // Past end of line.
+        assert_eq!(PositionEncoding::Utf16.col_from_utf8(line, 99), 99);
+        // Mid-character (byte 1 is inside the 3-byte 日).
+        assert_eq!(PositionEncoding::Utf16.col_from_utf8(line, 1), 1);
+    }
+}

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -17,7 +17,7 @@
 //! let location = client.goto_definition(
 //!     Path::new("src/main.rs"),
 //!     10,  // line (0-indexed)
-//!     5,   // column (0-indexed)
+//!     5,   // column (0-indexed byte offset)
 //! )?;
 //!
 //! // Clean shutdown
@@ -32,6 +32,7 @@
 //! - Request IDs are incrementing integers
 //! - Supports both successful responses and error responses
 
+mod encoding;
 mod error;
 mod provider;
 mod transport;

--- a/src/lsp/transport.rs
+++ b/src/lsp/transport.rs
@@ -7,10 +7,11 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use lsp_types::{
-    ClientCapabilities, DidOpenTextDocumentParams, GotoDefinitionParams, GotoDefinitionResponse,
-    InitializeParams, InitializeResult, Location, PartialResultParams, Position, ReferenceContext,
-    ReferenceParams, TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams, Uri,
-    WindowClientCapabilities, WorkDoneProgressParams,
+    ClientCapabilities, DidOpenTextDocumentParams, GeneralClientCapabilities, GotoDefinitionParams,
+    GotoDefinitionResponse, InitializeParams, InitializeResult, Location, PartialResultParams,
+    Position, PositionEncodingKind, ReferenceContext, ReferenceParams, TextDocumentIdentifier,
+    TextDocumentItem, TextDocumentPositionParams, Uri, WindowClientCapabilities,
+    WorkDoneProgressParams,
     notification::{DidOpenTextDocument, Notification},
     request::{GotoDefinition, Initialize, References, Shutdown},
 };
@@ -20,6 +21,7 @@ use serde_json::{Value, json};
 use tracing::{debug, trace, warn};
 
 use super::Result;
+use super::encoding::PositionEncoding;
 use super::error::LspError;
 use super::provider::LspProvider;
 
@@ -37,6 +39,10 @@ pub struct LspClient {
     stdout: BufReader<ChildStdout>,
     request_id: i64,
     response_timeout: Duration,
+    /// Position encoding negotiated during `initialize`. Tethys's stored
+    /// columns are byte offsets, so `Utf8` means outgoing positions pass
+    /// through unchanged; `Utf16` requires per-request conversion.
+    position_encoding: PositionEncoding,
     /// Background thread draining the server's stderr into tracing logs.
     /// Joined on shutdown to avoid leaking threads.
     stderr_thread: Option<JoinHandle<()>>,
@@ -130,6 +136,8 @@ impl LspClient {
             stdout,
             request_id: 0,
             response_timeout: DEFAULT_RESPONSE_TIMEOUT,
+            // LSP spec default until initialize() negotiates otherwise.
+            position_encoding: PositionEncoding::Utf16,
             stderr_thread,
         };
 
@@ -146,32 +154,56 @@ impl LspClient {
     fn initialize(&mut self, workspace_path: &Path, init_options: Option<Value>) -> Result<()> {
         let workspace_uri = path_to_uri(workspace_path)?;
 
-        // Set up client capabilities
-        // - window.workDoneProgress: We handle server->client requests with null responses,
-        //   which satisfies the progress protocol. This prevents servers like csharp-ls from
-        //   having issues when they try to report progress.
-        let capabilities = ClientCapabilities {
-            window: Some(WindowClientCapabilities {
-                work_done_progress: Some(true),
-                ..Default::default()
-            }),
-            ..Default::default()
-        };
-
         let params = InitializeParams {
             root_uri: Some(workspace_uri),
-            capabilities,
+            capabilities: client_capabilities(),
             initialization_options: init_options,
             ..Default::default()
         };
 
-        let _result: InitializeResult = self.send_request::<Initialize>(params)?;
+        let result: InitializeResult = self.send_request::<Initialize>(params)?;
+        self.position_encoding = PositionEncoding::from_initialize_result(&result);
 
         // Send initialized notification
         self.send_notification("initialized", &json!({}))?;
 
-        debug!("LSP initialize handshake complete");
+        debug!(
+            position_encoding = ?self.position_encoding,
+            "LSP initialize handshake complete"
+        );
         Ok(())
+    }
+
+    /// Convert an outgoing 0-indexed BYTE column to the negotiated encoding.
+    ///
+    /// Identity when the server accepted `utf-8` (tethys's stored columns
+    /// ARE byte offsets). When the negotiated encoding is `utf-16`, the
+    /// target line's text is read and its byte prefix re-measured as
+    /// `utf-16` code units. On a line-text read failure the raw byte offset
+    /// is sent rather than dropping the request — correct for ASCII-only
+    /// prefixes, best-effort otherwise.
+    fn encode_outgoing_col(&self, file: &Path, line: u32, byte_col: u32) -> u32 {
+        if self.position_encoding == PositionEncoding::Utf8 {
+            return byte_col;
+        }
+        let line_text = match std::fs::read_to_string(file) {
+            Ok(content) => usize::try_from(line)
+                .ok()
+                .and_then(|n| content.lines().nth(n).map(str::to_owned)),
+            Err(e) => {
+                debug!(
+                    file = %file.display(),
+                    line,
+                    error = %e,
+                    "Cannot read line text for utf-16 conversion; sending raw byte column"
+                );
+                None
+            }
+        };
+        match line_text {
+            Some(text) => self.position_encoding.col_from_utf8(&text, byte_col),
+            None => byte_col,
+        }
     }
 
     /// Send an LSP request and wait for the response.
@@ -361,7 +393,8 @@ impl LspClient {
     ///
     /// * `file` - Path to the source file
     /// * `line` - Line number (0-indexed)
-    /// * `col` - Column number (0-indexed)
+    /// * `col` - Column number (0-indexed BYTE offset; converted to the
+    ///   negotiated position encoding before sending)
     ///
     /// # Returns
     ///
@@ -378,6 +411,7 @@ impl LspClient {
         col: u32,
     ) -> Result<Option<Location>> {
         let uri = path_to_uri(file)?;
+        let col = self.encode_outgoing_col(file, line, col);
 
         let params = GotoDefinitionParams {
             text_document_position_params: TextDocumentPositionParams {
@@ -569,7 +603,8 @@ impl LspClient {
     ///
     /// * `file` - Path to the source file
     /// * `line` - Line number (0-indexed)
-    /// * `col` - Column number (0-indexed)
+    /// * `col` - Column number (0-indexed BYTE offset; converted to the
+    ///   negotiated position encoding before sending)
     ///
     /// # Returns
     ///
@@ -581,6 +616,7 @@ impl LspClient {
     /// Returns an error if the file path is invalid or communication fails.
     pub fn find_references(&mut self, file: &Path, line: u32, col: u32) -> Result<Vec<Location>> {
         let uri = path_to_uri(file)?;
+        let col = self.encode_outgoing_col(file, line, col);
 
         let params = ReferenceParams {
             text_document_position: TextDocumentPositionParams {
@@ -676,6 +712,35 @@ impl Drop for LspClient {
         // Reap the child process to prevent zombies. The exit status is
         // irrelevant during cleanup — we already attempted kill() above.
         let _ = self.process.wait();
+    }
+}
+
+/// Client capabilities advertised during the `initialize` handshake.
+///
+/// - `window.workDoneProgress`: We handle server->client requests with null
+///   responses, which satisfies the progress protocol. This prevents servers
+///   like csharp-ls from having issues when they try to report progress.
+/// - `general.positionEncodings` (LSP 3.17): `utf-8` is listed first because
+///   tethys's stored columns ARE byte offsets — a server that accepts it
+///   (rust-analyzer does) makes outgoing position conversion an identity
+///   no-op. `utf-16` is the spec-mandated fallback every server supports.
+///   Without this advert, servers assume `utf-16` and byte columns point at
+///   the wrong character on any line with non-ASCII text before the
+///   reference.
+fn client_capabilities() -> ClientCapabilities {
+    ClientCapabilities {
+        window: Some(WindowClientCapabilities {
+            work_done_progress: Some(true),
+            ..Default::default()
+        }),
+        general: Some(GeneralClientCapabilities {
+            position_encodings: Some(vec![
+                PositionEncodingKind::UTF8,
+                PositionEncodingKind::UTF16,
+            ]),
+            ..Default::default()
+        }),
+        ..Default::default()
     }
 }
 
@@ -854,6 +919,32 @@ mod tests {
 
     fn parse_uri(s: &str) -> Uri {
         s.parse().expect("valid URI")
+    }
+
+    /// Position-encoding fence (tethys-2d1x bug class): the `initialize`
+    /// handshake must advertise `general.positionEncodings` with `utf-8`
+    /// preferred (identity for tethys's stored byte columns) and `utf-16`
+    /// as the spec-mandated fallback. Without the advert, servers assume
+    /// `utf-16` and byte columns land on the wrong character on any line
+    /// with non-ASCII text before the reference.
+    #[test]
+    fn client_capabilities_advertise_utf8_first_position_encoding() {
+        let caps = client_capabilities();
+        let encodings = caps
+            .general
+            .expect("general client capabilities must be declared")
+            .position_encodings
+            .expect("positionEncodings must be declared");
+
+        assert_eq!(
+            encodings.first(),
+            Some(&PositionEncodingKind::UTF8),
+            "utf-8 must be preferred: stored columns are byte offsets"
+        );
+        assert!(
+            encodings.contains(&PositionEncodingKind::UTF16),
+            "utf-16 is the mandatory fallback every server supports"
+        );
     }
 
     #[test]

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1027,7 +1027,13 @@ impl Tethys {
             return Ok(false);
         };
 
-        // LSP returns 0-indexed, convert to 1-indexed for DB lookup
+        // LSP returns 0-indexed, convert to 1-indexed for DB lookup.
+        //
+        // ENCODING FENCE: only the LINE of the incoming range is used —
+        // match-back is line-granular and line numbers are identical in every
+        // position encoding. If match-back ever becomes column-sensitive,
+        // incoming columns are in the negotiated encoding (see
+        // src/lsp/encoding.rs) and need the inverse conversion to bytes.
         let def_line = definition.range.start.line + 1;
 
         // Find the symbol at that line
@@ -1210,7 +1216,9 @@ impl Tethys {
                 continue;
             };
 
-            // LSP returns 0-indexed, convert to 1-indexed for DB lookup
+            // LSP returns 0-indexed, convert to 1-indexed for DB lookup.
+            // ENCODING FENCE: line-granular match-back — see the fence note
+            // in resolve_single_ref_via_lsp before adding column use here.
             let ref_line = loc.range.start.line + 1;
 
             // Find the symbol that contains this reference location

--- a/tests/lsp_resolution.rs
+++ b/tests/lsp_resolution.rs
@@ -271,6 +271,139 @@ fn internal_work() -> i32 {
     );
 }
 
+/// Position encoding fence (byte columns vs `utf-16` code units): a
+/// `goto_definition` at a byte column AFTER non-ASCII text on the same line
+/// must land on the right symbol.
+///
+/// Tethys stores tree-sitter columns, which are BYTE offsets (`utf-8` code
+/// units). LSP positions default to `utf-16` code units unless an encoding
+/// is negotiated at `initialize`. Without negotiation, a method call after a
+/// CJK string literal is queried at a column far past its real position and
+/// rust-analyzer finds no definition (verified: byte col 55 vs `utf-16` col
+/// 35 on this fixture line). Negotiating `utf-8` — which rust-analyzer
+/// accepts — makes the stored byte column exact.
+///
+/// This exercises `LspClient` directly rather than the full indexing
+/// pipeline: Pass 3 currently queries rust-analyzer immediately after
+/// `initialize`, racing its asynchronous workspace load, so pipeline-level
+/// LSP resolution is not deterministic on a cold fixture (tracked
+/// separately from the encoding defect this test fences).
+#[test]
+#[ignore = "requires rust-analyzer installed"]
+fn lsp_resolves_ref_after_non_ascii_text_on_same_line() {
+    use tethys::lsp::{LspClient, RustAnalyzerProvider};
+
+    if !rust_analyzer_available() {
+        eprintln!("Skipping test: rust-analyzer not available");
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("failed to create temp dir");
+    fs::create_dir_all(dir.path().join("src")).expect("failed to create src dir");
+
+    // The `w.render()` call sits after a CJK + em-dash string literal on the
+    // same line: its byte column (55) is far larger than its utf-16 column
+    // (35). The receiver comes from a call so rust-analyzer must infer its
+    // type — same shape the indexing pipeline sends to Pass 3.
+    let lib_rs_content = "pub mod other;
+
+pub struct Widget;
+
+impl Widget {
+    pub fn render(&self) -> i32 {
+        1
+    }
+}
+
+pub fn make_widget() -> Widget {
+    Widget
+}
+
+pub fn draw() -> i32 {
+    let w = make_widget();
+    let _label = \"\u{65e5}\u{672c}\u{8a9e}\u{30e9}\u{30d9}\u{30eb} \u{2014} \u{30c6}\u{30b9}\u{30c8}\"; w.render()
+}
+";
+    let lib_rs = dir.path().join("src/lib.rs");
+    fs::write(&lib_rs, lib_rs_content).expect("failed to write lib.rs");
+
+    fs::write(
+        dir.path().join("src/other.rs"),
+        "pub struct Panel;
+
+impl Panel {
+    pub fn render(&self) -> i32 {
+        2
+    }
+}
+",
+    )
+    .expect("failed to write other.rs");
+
+    create_cargo_toml(&dir);
+
+    // Locate the call and the definition by content, byte-offset columns —
+    // exactly what tethys stores from tree-sitter.
+    let (call_line, call_col) = find_byte_position(lib_rs_content, "w.render()", "render");
+    let (def_line, _) = find_byte_position(lib_rs_content, "pub fn render", "render");
+
+    let mut client =
+        LspClient::start(&RustAnalyzerProvider, dir.path()).expect("failed to start LSP client");
+    client
+        .did_open(&lib_rs, lib_rs_content, "rust")
+        .expect("didOpen failed");
+
+    // rust-analyzer loads the workspace asynchronously after initialize and
+    // answers goto_definition with None — or a transient -32801 "content
+    // modified" error — until it finishes (~2s on this fixture); poll until
+    // it produces an answer.
+    let mut definition = None;
+    for _ in 0..60 {
+        match client.goto_definition(&lib_rs, call_line, call_col) {
+            Ok(Some(loc)) => {
+                definition = Some(loc);
+                break;
+            }
+            Ok(None) | Err(tethys::lsp::LspError::ServerError { code: -32801, .. }) => {
+                std::thread::sleep(std::time::Duration::from_millis(500));
+            }
+            Err(e) => panic!("goto_definition failed: {e}"),
+        }
+    }
+    client.shutdown().expect("shutdown failed");
+
+    let definition = definition.expect(
+        "goto_definition at the byte column of w.render() (after the non-ASCII \
+         literal) should find Widget::render — a miss means the position was \
+         interpreted in the wrong encoding",
+    );
+
+    assert!(
+        definition.uri.as_str().ends_with("src/lib.rs"),
+        "definition should be in lib.rs, got {}",
+        definition.uri.as_str()
+    );
+    assert_eq!(
+        definition.range.start.line, def_line,
+        "definition should be Widget::render's declaration line"
+    );
+}
+
+/// Find `needle` inside the first line containing `line_marker` and return
+/// its 0-indexed (line, byte column) — tree-sitter position semantics.
+fn find_byte_position(content: &str, line_marker: &str, needle: &str) -> (u32, u32) {
+    let (idx, line) = content
+        .lines()
+        .enumerate()
+        .find(|(_, l)| l.contains(line_marker))
+        .expect("marker line present in fixture");
+    let col = line.find(needle).expect("needle present on marker line");
+    (
+        u32::try_from(idx).expect("line fits u32"),
+        u32::try_from(col).expect("col fits u32"),
+    )
+}
+
 /// Test LSP resolution with generic types and type parameters.
 #[test]
 #[ignore = "requires rust-analyzer installed"]


### PR DESCRIPTION
Fixes the tethys-2d1x bug class: LSP positions were sent as tree-sitter BYTE columns while servers interpreted them as UTF-16 code units (the LSP default, never negotiated), so `goto_definition`/`find_references` missed on any line with non-ASCII text before the reference column.

## Repro

`tests/lsp_resolution.rs::lsp_resolves_ref_after_non_ascii_text_on_same_line` (`#[ignore]`d, nightly LSP job): a `w.render()` call after a CJK + em-dash string literal on the same line — byte column 55, utf-16 column 35. Before the fix, `LspClient::goto_definition` at the stored byte column returns `None` forever (verified red: 30s poll exhausted). A raw JSON-RPC probe against rust-analyzer confirmed the mechanism both ways: with no `positionEncodings` advert the server reports `utf-16` and returns `[]` at byte col 55 but the correct `Widget::render` at utf-16 col 35; with `["utf-8","utf-16"]` advertised it reports `utf-8` and returns the correct target at byte col 55.

An earlier attempt to express the repro through the full indexing pipeline (assert `strategy = 'lsp'` in the DB) turned out to be blocked by a *separate* defect — see "Discovered, not fixed" below — so the test pins the defect at the `LspClient` seam, which is exactly where the encoding conversion lives.

## Cause

- `src/languages/tree_sitter_utils.rs` stores tree-sitter `Point` columns, which are byte offsets.
- `src/resolve.rs` passed them to LSP with only a 1→0 index shift.
- `src/lsp/transport.rs` declared only `window.workDoneProgress` in `ClientCapabilities`; `general.positionEncodings` (LSP 3.17) was absent, so servers assumed utf-16.

## Fix

- New pure module `src/lsp/encoding.rs`: `PositionEncoding` (negotiation from the `initialize` result, utf-16 spec-default fallback) and `col_from_utf8` (byte column → negotiated encoding; utf-8 is identity, utf-16 re-measures the line's byte prefix via `encode_utf16().count()`).
- `transport.rs` advertises `general.positionEncodings: ["utf-8", "utf-16"]` (utf-8 first: tethys's stored offsets ARE byte offsets, so a server that accepts it — rust-analyzer does — makes conversion a no-op), captures the server's choice, and converts outgoing columns in `goto_definition`/`find_references`. On a line-text read failure the raw offset is sent rather than dropping the request.
- Incoming ranges: match-back is line-granular (`find_symbol_at_line`) and line numbers are encoding-independent; comment fences added at both match-back sites in `resolve.rs` for if that ever becomes column-sensitive.

## Fence

- `src/lsp/encoding.rs` unit tests: negotiation (utf-8 chosen / absent / unadvertised kind), ASCII identity, multibyte-before-column, multibyte-after-column identity, emoji surrogate pair (4 utf-8 bytes = 2 utf-16 units), utf-8 identity, out-of-range/mid-char fallback.
- `transport.rs::client_capabilities_advertise_utf8_first_position_encoding`: the capability advert itself.
- `tests/lsp_resolution.rs::lsp_resolves_ref_after_non_ascii_text_on_same_line` (`#[ignore]`d like its siblings): end-to-end against rust-analyzer; red without the fix, green with it (3/3 stable runs).

## Discovered, not fixed

Pass 3 queries rust-analyzer immediately after `initialize`, racing its asynchronous workspace load — `src/resolve.rs` (comment near the `wait_for_solution_load` call) claims "rust-analyzer indexes on startup and responds immediately, so no wait needed", which is false: on a cold fixture every `goto_definition` returns empty/`-32801 content modified` until loading finishes (~2s), so pipeline-level LSP resolution silently resolves nothing. This is why the existing LSP integration tests only pass via their tree-sitter-resolved assertions. Reported to the tracker owner rather than fixed here (separate root cause, own design space: readiness signal choice).

Gate: nextest, clippy `-D warnings`, fmt --check, doctests all green; changelog fragment `changelog.d/tethys-2d1x.fixed.md` included.