### PR TITLE
feat(callers): expose explicit caller modes (tethys-5n64)

### DIFF
--- a/.agents/summary/components.md
+++ b/.agents/summary/components.md
@@ -50,12 +50,12 @@ The domain model and the largest single source file. Defines the core records
 (`Symbol`, `Reference`, `Import`, `IndexedFile`, `Span`), strongly-typed IDs
 (`SymbolId`, `FileId`, `RefId`, `PackageId`), enums (`Language`, `SymbolKind`,
 `Visibility`, `ReferenceKind`, `PanicKind`, `ReachabilityDirection`,
-`CouplingSort`), signatures (`FunctionSignature`, `Parameter`, `ParameterKind`),
-result/stat structures (`IndexStats`, `DatabaseStats`, `Impact`,
-`ReachabilityResult`, `Cycle`, `StalenessReport`, `IndexUpdate`), architecture
-types (`Package`, `CouplingMetrics`, `CouplingDetail`, `PackageDependency`,
-`ArchStats`), LSP outcome types, and `IndexOptions`/`CrateInfo`. See
-`data_models.md`.
+`CallEdgeSelection`, `CallerMode`, `CouplingSort`), signatures
+(`FunctionSignature`, `Parameter`, `ParameterKind`), result/stat structures
+(`Caller`, `IndexStats`, `DatabaseStats`, `Impact`, `ReachabilityResult`,
+`Cycle`, `StalenessReport`, `IndexUpdate`), architecture types (`Package`,
+`CouplingMetrics`, `CouplingDetail`, `PackageDependency`, `ArchStats`), LSP
+outcome types, and `IndexOptions`/`CrateInfo`. See `data_models.md`.
 
 ### `error` (`src/error.rs`)
 `Error` (top-level, re-exported), `IndexError`, and `IndexErrorKind`. Distinguishes
@@ -94,8 +94,9 @@ The **language-neutral** cross-file reference resolution driver. Builds import
 maps per file (`build_import_maps`), resolves references via explicit imports,
 glob imports, and qualified-module fallback (`try_resolve_reference`,
 `resolve_symbol_in_module`, `resolve_module_to_file_id`), and optionally refines
-via LSP (`resolve_via_lsp`, `get_callers_with_lsp`). Holds `ResolveContext`. Must
-not contain language-specific module semantics (enforced by `seam_lint`).
+references and direct callers via LSP (`resolve_via_lsp`,
+`get_lsp_refined_callers`). Holds `ResolveContext`. Must not contain
+language-specific module semantics (enforced by `seam_lint`).
 
 ### `resolver.rs`
 Rust-specific module-path resolution: maps `crate::`, `self::`, `super::`, and

--- a/.agents/summary/interfaces.md
+++ b/.agents/summary/interfaces.md
@@ -16,7 +16,7 @@ Invoked as `tethys <command> [args]`. Global options apply to all commands:
 |---------|-------------------|---------|
 | `index` | `--rebuild`, `--lsp`, `--lsp-timeout <SECS>` | Index (or rebuild) the workspace. `--lsp` enables rust-analyzer refinement; timeout env `TETHYS_LSP_TIMEOUT`. |
 | `search <query>` | `-k/--kind <KIND>`, `-l/--limit <N>` (default 20) | Search symbols by name (partial match), optionally filtered by kind. |
-| `callers <symbol>` | `-t/--transitive`, `--lsp` | Show callers of a qualified symbol; transitive walks the call chain. |
+| `callers <symbol>` | `-t/--transitive`, `--lsp`, `--exclude-speculative` | Show callers of a qualified symbol. `--lsp` is direct-only and conflicts with both other flags. |
 | `impact <target>` | `-s/--symbol`, `-d/--depth <N>` (default 50), `--lsp` | Impact of changing a file (or symbol with `--symbol`). |
 | `coupling` | `--sort <KEY>`, `--package <NAME>`, `--json` | Per-crate coupling (Ca, Ce, instability). `--package` drills into one (conflicts with `--sort`). |
 | `cycles` | — | Detect circular dependencies. |
@@ -56,7 +56,7 @@ classDiagram
         +get_symbol(qualified_name) Result
         +list_symbols(file) Result
         +get_references(symbol) Result~Vec~Reference~~
-        +get_callers(symbol) Result
+        +get_callers(symbol, CallerMode) Result~Vec~Caller~~
         +get_impact(file, depth) Result~Impact~
         +get_symbol_impact(symbol, depth) Result~Impact~
         +get_dependencies(file) Result
@@ -73,6 +73,12 @@ classDiagram
         +vacuum() Result
     }
 ```
+
+Direct caller queries require `CallerMode::Indexed { call_edges }` or
+`CallerMode::LspRefined`. `CallEdgeSelection::ExcludeSpeculative` drops only
+edges whose every supporting reference is speculative; mixed-support edges
+survive. Each `Caller` identifies the caller `Symbol` and its workspace-relative
+indexed-file path.
 
 `discover_crates` is also re-exported at the crate root for standalone Cargo
 discovery.

--- a/.agents/summary/workflows.md
+++ b/.agents/summary/workflows.md
@@ -100,13 +100,23 @@ sequenceDiagram
     participant CLI
     participant Tethys
     participant DB as SQLite
-    User->>CLI: tethys callers "Foo::bar" --transitive
-    CLI->>Tethys: get_callers / transitive
-    Tethys->>DB: recursive CTE over call_edges
-    DB-->>Tethys: caller rows
-    Tethys-->>CLI: CallerInfo / SymbolImpact
+    participant LSP
+    User->>CLI: tethys callers "Foo::bar" [--lsp | --exclude-speculative]
+    CLI->>Tethys: get_callers("Foo::bar", CallerMode)
+    Tethys->>DB: query retained call_edges and hydrate caller files
+    DB-->>Tethys: indexed caller records
+    opt LspRefined
+        Tethys->>LSP: find_references at target definition
+        LSP-->>Tethys: reference locations
+        Tethys->>Tethys: merge and deduplicate by caller symbol
+    end
+    Tethys-->>CLI: Caller rows
     CLI-->>User: grouped, formatted output
 ```
+
+Transitive callers remain index-backed through symbol impact. The CLI rejects
+`--lsp` with either `--transitive` or `--exclude-speculative`; unsupported
+combinations are never silently ignored.
 
 `impact` works the same way at file granularity over `file_deps`, or at symbol
 granularity with `--symbol`. `--depth` bounds transitive traversal.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,11 @@ For "what is X / how do I call X / how does process Y work", route via
   lives in `src/db/graph.rs` behind the public `Tethys` facade. There is no
   graph adapter trait or in-memory graph library; reach for SQL-backed methods,
   and introduce a narrow seam only when a second implementation exists.
+- **Direct caller modes are explicit at the `Tethys` seam.**
+  `CallerMode::Indexed` selects all retained call edges or excludes edges
+  supported only by speculative references; `CallerMode::LspRefined` augments
+  all indexed callers and is direct-only. The CLI rejects `--lsp` with
+  `--exclude-speculative` or `--transitive` rather than ignoring either flag.
 - **Coupling instability is computed in Rust, not SQL.** The `arch_coupling`
   view yields only Ca/Ce; `CouplingMetrics::instability` owns the formula.
   Keep it in one place.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -220,7 +220,12 @@ can reach); backward follows callers (what can reach this).
 
 **Callers**:
 The symbols that call a given symbol, directly or transitively — a backward
-call-graph query at symbol granularity.
+call-graph query at symbol granularity. Direct queries select an explicit
+**caller mode**: `Indexed` reads retained call edges under an all-edges or
+exclude-speculative-only policy; `LspRefined` augments all indexed callers with
+language-server findings and deduplicates by caller symbol. LSP refinement is
+direct-only and does not compose with speculative exclusion.
+_Avoid_: treating LSP refinement as a filter over indexed call edges
 
 **Affected tests**:
 The test symbols whose reachable set touches a set of changed files — the tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ colored = "3"
 
 [dev-dependencies]
 tempfile = "3.18"
+rusqlite = { version = "0.32", features = ["trace"] }
 rstest = "0.26"
 proptest = "1.6"
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/benches/queries.rs
+++ b/benches/queries.rs
@@ -194,7 +194,12 @@ fn bench_get_callers(c: &mut Criterion) {
                 b.iter(|| {
                     let callers = workspace
                         .tethys
-                        .get_callers("target_func", false)
+                        .get_callers(
+                            "target_func",
+                            tethys::CallerMode::Indexed {
+                                call_edges: tethys::CallEdgeSelection::All,
+                            },
+                        )
                         .expect("get_callers failed");
                     black_box(callers)
                 });
@@ -370,7 +375,12 @@ fn analyze_query_plans(c: &mut Criterion) {
         b.iter(|| {
             let callers = workspace
                 .tethys
-                .get_callers("target_func", false)
+                .get_callers(
+                    "target_func",
+                    tethys::CallerMode::Indexed {
+                        call_edges: tethys::CallEdgeSelection::All,
+                    },
+                )
                 .expect("get_callers failed");
             black_box(callers)
         });

--- a/changelog.d/tethys-5n64.changed.md
+++ b/changelog.d/tethys-5n64.changed.md
@@ -1,0 +1,2 @@
+- `tethys callers` now rejects `--lsp` with `--transitive` or `--exclude-speculative` instead of silently ignoring unsupported options.
+- LSP-refined caller queries now wait for workspace analysis and recover inferred callers from their containing symbols.

--- a/src/cli/callers.rs
+++ b/src/cli/callers.rs
@@ -4,9 +4,9 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use colored::Colorize;
-use tethys::Tethys;
+use tethys::{CallEdgeSelection, CallerMode, Tethys};
 
-use super::display::print_callers_by_file;
+use super::display::{print_callers_by_file, print_dependent_callers_by_file};
 use super::ensure_lsp_if_requested;
 
 /// Run the callers command.
@@ -44,7 +44,7 @@ pub fn run(
             .cloned()
             .collect();
         let unique_files: HashSet<_> = all_callers.iter().map(|c| &c.file).collect();
-        print_callers_by_file(&all_callers);
+        print_dependent_callers_by_file(&all_callers);
 
         let total = impact.direct_dependents.len() + impact.transitive_dependents.len();
         println!();
@@ -61,12 +61,18 @@ pub fn run(
             unique_files.len()
         );
     } else {
-        // Direct callers only - use LSP if requested
-        let callers = if lsp {
-            tethys.get_callers_with_lsp(symbol)?
+        let mode = if lsp {
+            CallerMode::LspRefined
         } else {
-            tethys.get_callers(symbol, exclude_speculative)?
+            CallerMode::Indexed {
+                call_edges: if exclude_speculative {
+                    CallEdgeSelection::ExcludeSpeculative
+                } else {
+                    CallEdgeSelection::All
+                },
+            }
         };
+        let callers = tethys.get_callers(symbol, mode)?;
 
         if callers.is_empty() {
             println!("No callers found for \"{}\"", symbol.cyan());

--- a/src/cli/display.rs
+++ b/src/cli/display.rs
@@ -1,10 +1,10 @@
 //! Common display utilities for CLI commands.
 
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::Path;
 
 use colored::Colorize;
-use tethys::Dependent;
+use tethys::{Caller, Dependent};
 
 const MAX_DISPLAY_ITEMS: usize = 10;
 
@@ -31,30 +31,52 @@ pub fn print_dependents(dependents: &[Dependent], empty_message: &str) {
     }
 }
 
-/// Group callers by file and display symbols used from each file.
-///
-/// Groups the given dependents by their source file, deduplicates symbols,
-/// and prints them in sorted order for deterministic output.
-pub fn print_callers_by_file(callers: &[Dependent]) {
-    // Group by file, deduplicating symbols
-    let mut by_file: HashMap<PathBuf, HashSet<String>> = HashMap::new();
-    for caller in callers {
-        by_file
-            .entry(caller.file.clone())
-            .or_default()
-            .extend(caller.symbols_used.iter().cloned());
+/// Group direct callers by indexed file and display their symbol names.
+pub fn print_callers_by_file(callers: &[Caller]) {
+    let grouped = group_callers(
+        callers
+            .iter()
+            .map(|caller| (caller.file.as_path(), caller.symbol.qualified_name.as_str())),
+    );
+    print_grouped_callers(grouped);
+}
+
+/// Group legacy symbol-impact dependents by file and display their symbol names.
+pub fn print_dependent_callers_by_file(callers: &[Dependent]) {
+    let grouped = group_callers(callers.iter().flat_map(|caller| {
+        caller
+            .symbols_used
+            .iter()
+            .map(move |symbol| (caller.file.as_path(), symbol.as_str()))
+    }));
+    print_grouped_callers(grouped);
+}
+
+fn group_callers<'a>(
+    callers: impl IntoIterator<Item = (&'a Path, &'a str)>,
+) -> Vec<(&'a Path, Vec<&'a str>)> {
+    let mut by_file = HashMap::<_, HashSet<_>>::new();
+    for (file, symbol) in callers {
+        by_file.entry(file).or_default().insert(symbol);
     }
 
-    // Sort files for deterministic output
-    let mut sorted_files: Vec<_> = by_file.iter().collect();
-    sorted_files.sort_by_key(|(path, _)| *path);
+    let mut grouped: Vec<_> = by_file
+        .into_iter()
+        .map(|(file, symbols)| {
+            let mut symbols: Vec<_> = symbols.into_iter().collect();
+            symbols.sort_unstable();
+            (file, symbols)
+        })
+        .collect();
+    grouped.sort_by(|(left, _), (right, _)| left.cmp(right));
+    grouped
+}
 
-    for (file, symbols) in sorted_files {
+fn print_grouped_callers(grouped: Vec<(&Path, Vec<&str>)>) {
+    for (file, symbols) in grouped {
         println!("  {}:", file.display().to_string().white().bold());
-        let mut sorted_symbols: Vec<_> = symbols.iter().collect();
-        sorted_symbols.sort();
-        for sym in sorted_symbols {
-            println!("    {} {}", "•".dimmed(), sym);
+        for symbol in symbols {
+            println!("    {} {}", "•".dimmed(), symbol);
         }
     }
 }
@@ -82,27 +104,20 @@ fn format_dependents(dependents: &[Dependent], empty_message: &str) -> Vec<Strin
 
 #[cfg(test)]
 fn format_callers_by_file(callers: &[Dependent]) -> Vec<String> {
-    let mut by_file: HashMap<PathBuf, HashSet<String>> = HashMap::new();
-    for caller in callers {
-        by_file
-            .entry(caller.file.clone())
-            .or_default()
-            .extend(caller.symbols_used.iter().cloned());
-    }
-
-    let mut sorted_files: Vec<_> = by_file.iter().collect();
-    sorted_files.sort_by_key(|(path, _)| *path);
+    let grouped = group_callers(callers.iter().flat_map(|caller| {
+        caller
+            .symbols_used
+            .iter()
+            .map(move |symbol| (caller.file.as_path(), symbol.as_str()))
+    }));
 
     let mut lines = Vec::new();
-    for (file, symbols) in sorted_files {
+    for (file, symbols) in grouped {
         lines.push(format!("  {}:", file.display()));
-        let mut sorted_symbols: Vec<_> = symbols.iter().collect();
-        sorted_symbols.sort();
-        for sym in sorted_symbols {
-            lines.push(format!("    • {sym}"));
+        for symbol in symbols {
+            lines.push(format!("    • {symbol}"));
         }
     }
-
     lines
 }
 

--- a/src/db/graph.rs
+++ b/src/db/graph.rs
@@ -8,7 +8,7 @@ use super::Index;
 use super::helpers::{row_to_indexed_file, row_to_symbol};
 use crate::error::{Error, Result};
 use crate::graph::{CallerInfo, FileDepInfo, FileImpact, FilePath, SymbolImpact};
-use crate::types::{Cycle, FileId, SymbolId};
+use crate::types::{CallEdgeSelection, Cycle, FileId, SymbolId};
 
 /// Default maximum depth for recursive graph traversals.
 ///
@@ -20,28 +20,27 @@ pub(crate) const DEFAULT_MAX_DEPTH: u32 = 50;
 /// whose band (per the `refs_banded` view — the single home of the ADR-0003
 /// mapping) is not speculative. Empty when the filter is off. `edge` is the
 /// `call_edges` alias in the enclosing query.
-fn edge_support_filter(exclude_speculative: bool, edge: &str) -> String {
-    if exclude_speculative {
-        format!(
+fn edge_support_filter(call_edges: CallEdgeSelection, edge: &str) -> String {
+    match call_edges {
+        CallEdgeSelection::ExcludeSpeculative => format!(
             " AND EXISTS (SELECT 1 FROM refs_banded rb
                           WHERE rb.in_symbol_id = {edge}.caller_symbol_id
                             AND rb.symbol_id = {edge}.callee_symbol_id
                             AND rb.band != 'speculative')"
-        )
-    } else {
-        String::new()
+        ),
+        CallEdgeSelection::All => String::new(),
     }
 }
 
 impl Index {
     /// Get symbols that directly call/reference the given symbol.
     ///
-    /// `exclude_speculative` drops call edges whose every supporting ref
-    /// bands speculative in `refs_banded`.
+    /// [`CallEdgeSelection::ExcludeSpeculative`] drops call edges whose every
+    /// supporting reference bands speculative in `refs_banded`.
     pub fn get_callers(
         &self,
         symbol_id: SymbolId,
-        exclude_speculative: bool,
+        call_edges: CallEdgeSelection,
     ) -> Result<Vec<CallerInfo>> {
         let conn = self.connection()?;
 
@@ -50,16 +49,14 @@ impl Index {
             &"SELECT
                 s.id, s.file_id, s.name, s.module_path, s.qualified_name,
                 s.kind, s.line, s.column, s.end_line, s.end_column,
-                s.signature, s.visibility, s.parent_symbol_id,
-                ce.call_count
+                s.signature, s.visibility, s.parent_symbol_id, s.is_test,
+                ce.call_count, f.path
              FROM call_edges ce
              JOIN symbols s ON s.id = ce.caller_symbol_id
+             JOIN files f ON f.id = s.file_id
              WHERE ce.callee_symbol_id = ?1{exclusion}
              ORDER BY s.qualified_name"
-                .replace(
-                    "{exclusion}",
-                    &edge_support_filter(exclude_speculative, "ce"),
-                ),
+                .replace("{exclusion}", &edge_support_filter(call_edges, "ce")),
         )?;
 
         let callers = stmt
@@ -71,10 +68,13 @@ impl Index {
                     clippy::cast_sign_loss,
                     reason = "call_count is a non-negative SQL COUNT aggregate"
                 )]
-                let ref_count: usize = row.get::<_, i64>(13)? as usize;
+                let ref_count: usize = row.get::<_, i64>(14)? as usize;
 
                 Ok(CallerInfo {
-                    symbol,
+                    caller: crate::types::Caller {
+                        symbol,
+                        file: row.get::<_, String>(15)?.into(),
+                    },
                     reference_count: ref_count,
                 })
             })?
@@ -137,15 +137,23 @@ impl Index {
             SELECT DISTINCT
                 s.id, s.file_id, s.name, s.module_path, s.qualified_name,
                 s.kind, s.line, s.column, s.end_line, s.end_column,
-                s.signature, s.visibility, s.parent_symbol_id,
-                MIN(ct.depth) as min_depth
+                s.signature, s.visibility, s.parent_symbol_id, s.is_test,
+                f.path, MIN(ct.depth) as min_depth
             FROM caller_tree ct
             JOIN symbols s ON s.id = ct.symbol_id
+            JOIN files f ON f.id = s.file_id
             GROUP BY s.id
             ORDER BY min_depth, s.qualified_name"
                 .replace(
                     "{exclusion}",
-                    &edge_support_filter(exclude_speculative, "ce"),
+                    &edge_support_filter(
+                        if exclude_speculative {
+                            CallEdgeSelection::ExcludeSpeculative
+                        } else {
+                            CallEdgeSelection::All
+                        },
+                        "ce",
+                    ),
                 ),
         )?;
 
@@ -160,15 +168,16 @@ impl Index {
                 clippy::cast_sign_loss,
                 reason = "CTE depth bounded by max_depth (u32)"
             )]
-            let depth: u32 = row.get::<_, i64>(13)? as u32;
-            Ok((symbol, depth))
+            let depth: u32 = row.get::<_, i64>(15)? as u32;
+            let file = row.get::<_, String>(14)?.into();
+            Ok((symbol, file, depth))
         })?;
 
         for row in rows {
-            let (symbol, depth) = row?;
+            let (symbol, file, depth) = row?;
 
             let caller_info = CallerInfo {
-                symbol,
+                caller: crate::types::Caller { symbol, file },
                 reference_count: 1,
             };
 

--- a/src/db/graph.rs
+++ b/src/db/graph.rs
@@ -8,7 +8,7 @@ use super::Index;
 use super::helpers::{row_to_indexed_file, row_to_symbol};
 use crate::error::{Error, Result};
 use crate::graph::{CallerInfo, FileDepInfo, FileImpact, FilePath, SymbolImpact};
-use crate::types::{CallEdgeSelection, Cycle, FileId, SymbolId};
+use crate::types::{CallEdgeSelection, Caller, Cycle, FileId, SymbolId};
 
 /// Default maximum depth for recursive graph traversals.
 ///
@@ -71,7 +71,7 @@ impl Index {
                 let ref_count: usize = row.get::<_, i64>(14)? as usize;
 
                 Ok(CallerInfo {
-                    caller: crate::types::Caller {
+                    caller: Caller {
                         symbol,
                         file: row.get::<_, String>(15)?.into(),
                     },
@@ -177,7 +177,7 @@ impl Index {
             let (symbol, file, depth) = row?;
 
             let caller_info = CallerInfo {
-                caller: crate::types::Caller { symbol, file },
+                caller: Caller { symbol, file },
                 reference_count: 1,
             };
 

--- a/src/db/symbols.rs
+++ b/src/db/symbols.rs
@@ -474,6 +474,39 @@ impl Index {
         .optional()
         .map_err(Into::into)
     }
+
+    /// Find the innermost indexed symbol whose source span contains a line.
+    ///
+    /// This maps an LSP reference location back to its caller. Symbols that
+    /// start later take precedence over enclosing type declarations; for equal
+    /// starts, the symbol ending first is the narrower span.
+    pub fn find_symbol_containing_line(
+        &self,
+        file_id: FileId,
+        line: u32,
+    ) -> Result<Option<Symbol>> {
+        trace!(
+            file_id = %file_id,
+            line,
+            "Finding symbol containing line"
+        );
+
+        let conn = self.connection()?;
+        conn.query_row(
+            &format!(
+                "SELECT {SYMBOLS_COLUMNS} FROM symbols \
+                 WHERE file_id = ?1 \
+                   AND line <= ?2 \
+                   AND COALESCE(end_line, line) >= ?2 \
+                 ORDER BY line DESC, COALESCE(end_line, line) ASC, column DESC \
+                 LIMIT 1"
+            ),
+            params![file_id.as_i64(), line],
+            row_to_symbol,
+        )
+        .optional()
+        .map_err(Into::into)
+    }
 }
 
 #[cfg(test)]

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -1,12 +1,12 @@
 //! Internal result types for graph queries.
 
-use crate::types::{IndexedFile, Symbol};
+use crate::types::{Caller, IndexedFile};
 
 /// Information about a caller of a symbol.
 #[derive(Debug, Clone)]
 pub struct CallerInfo {
-    /// The symbol that calls the target.
-    pub symbol: Symbol,
+    /// Caller identity and indexed-file path.
+    pub caller: Caller,
     /// How many times it references the target.
     pub reference_count: usize,
 }

--- a/src/languages/mod.rs
+++ b/src/languages/mod.rs
@@ -28,7 +28,7 @@ mod tree_sitter_utils;
 
 use common::{ExtractedReference, ExtractedSymbol, ImportStatement};
 
-use crate::types::Language;
+use crate::types::{Language, Span};
 
 /// Get the language support implementation for a language.
 #[must_use]
@@ -47,6 +47,17 @@ pub trait LanguageSupport: Send + Sync {
     /// Get the tree-sitter language for parsing.
     fn tree_sitter_language(&self) -> tree_sitter::Language;
 
+    /// Locate the declared identifier for an indexed syntax-node span.
+    ///
+    /// Returns 1-indexed `(line, byte column)` coordinates. The default
+    /// implementation reparses the source and reads the declaration node's
+    /// tree-sitter `name` field.
+    fn definition_name_position(&self, content: &[u8], span: Span) -> Option<(u32, u32)> {
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&self.tree_sitter_language()).ok()?;
+        let tree = parser.parse(content, None)?;
+        tree_sitter_utils::name_position_for_span(tree.root_node(), span)
+    }
     /// Extract symbols from a parsed syntax tree.
     fn extract_symbols(&self, tree: &tree_sitter::Tree, content: &[u8]) -> Vec<ExtractedSymbol>;
 
@@ -59,4 +70,35 @@ pub trait LanguageSupport: Send + Sync {
 
     /// Extract import statements from a parsed syntax tree.
     fn extract_imports(&self, tree: &tree_sitter::Tree, content: &[u8]) -> Vec<ImportStatement>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::SymbolKind;
+
+    #[test]
+    fn definition_name_position_ignores_name_in_visibility_path() {
+        let source = "pub(in crate::worker) fn worker() {}";
+        let support = get_language_support(Language::Rust);
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&support.tree_sitter_language())
+            .expect("Rust grammar");
+        let tree = parser.parse(source, None).expect("parse source");
+        let symbol = support
+            .extract_symbols(&tree, source.as_bytes())
+            .into_iter()
+            .find(|symbol| symbol.kind == SymbolKind::Function && symbol.name == "worker")
+            .expect("worker function");
+        let span = symbol.span.expect("function span");
+
+        let position = support
+            .definition_name_position(source.as_bytes(), span)
+            .expect("declaration name position");
+        let expected_column =
+            u32::try_from(source.rfind("worker").expect("function name")).expect("column") + 1;
+
+        assert_eq!(position, (1, expected_column));
+    }
 }

--- a/src/languages/tree_sitter_utils.rs
+++ b/src/languages/tree_sitter_utils.rs
@@ -27,6 +27,26 @@ pub fn node_text(node: &tree_sitter::Node, content: &[u8]) -> Option<String> {
     }
 }
 
+/// Find the declared name position for the node matching an indexed span.
+///
+/// Both coordinates are 1-indexed. Matching the syntax node before reading
+/// its `name` field avoids confusing an identifier in visibility modifiers or
+/// return types with the declaration's own identifier.
+pub fn name_position_for_span(node: tree_sitter::Node<'_>, target: Span) -> Option<(u32, u32)> {
+    if node_span(&node) == target
+        && let Some(name) = node.child_by_field_name("name")
+    {
+        return Some((
+            name.start_position().row as u32 + 1,
+            name.start_position().column as u32 + 1,
+        ));
+    }
+
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .find_map(|child| name_position_for_span(child, target))
+}
+
 /// Convert tree-sitter positions to our Span type.
 ///
 /// Tree-sitter uses 0-indexed positions; Span uses 1-indexed.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,13 +57,14 @@ pub use db::{
 pub use dead_code::{DeadCodeFinding, DeadCodeReport, DeadCodeSummary};
 pub use error::{Error, IndexError, IndexErrorKind, Result};
 pub use types::{
-    ArchPhaseResult, ArchStats, CouplingDetail, CouplingMetrics, CouplingSort, CrateInfo, Cycle,
-    DatabaseStats, Dependent, FileAnalysis, FileId, FunctionSignature, Impact, Import,
-    IndexOptions, IndexStats, IndexUpdate, IndexedFile, Language, LspCompletedSession, LspOutcome,
-    LspSessionResult, Package, PackageDependency, PackageId, PackageSource, PanicKind, PanicPoint,
-    Parameter, ParameterKind, ReachabilityDirection, ReachabilityResult, ReachablePath, Reference,
-    ReferenceKind, ResolutionStrategy, Span, StalenessReport, Symbol, SymbolId, SymbolKind,
-    UnresolvedRefForLsp, Visibility,
+    ArchPhaseResult, ArchStats, CallEdgeSelection, Caller, CallerMode, CouplingDetail,
+    CouplingMetrics, CouplingSort, CrateInfo, Cycle, DatabaseStats, Dependent, FileAnalysis,
+    FileId, FunctionSignature, Impact, Import, IndexOptions, IndexStats, IndexUpdate, IndexedFile,
+    Language, LspCompletedSession, LspOutcome, LspSessionResult, Package, PackageDependency,
+    PackageId, PackageSource, PanicKind, PanicPoint, Parameter, ParameterKind,
+    ReachabilityDirection, ReachabilityResult, ReachablePath, Reference, ReferenceKind,
+    ResolutionStrategy, Span, StalenessReport, Symbol, SymbolId, SymbolKind, UnresolvedRefForLsp,
+    Visibility,
 };
 pub use unused_imports::{UnusedImport, UnusedImportConfidence};
 
@@ -112,6 +113,17 @@ fn saturating_depth_to_u32(depth: usize) -> u32 {
         );
         u32::MAX
     })
+}
+
+fn callers_to_dependents(callers: Vec<graph::CallerInfo>) -> Vec<Dependent> {
+    callers
+        .into_iter()
+        .map(|caller| Dependent {
+            file: caller.caller.file,
+            symbols_used: vec![caller.caller.symbol.qualified_name],
+            line_count: caller.reference_count,
+        })
+        .collect()
 }
 
 #[expect(
@@ -433,25 +445,23 @@ impl Tethys {
         })
     }
 
-    /// Get symbols that call/use the given symbol.
+    /// Get symbols that directly call/use the given symbol.
     ///
-    /// `exclude_speculative` drops call edges whose every supporting ref
-    /// bands speculative (ADR-0003 via the `refs_banded` view) — the
-    /// name-shape fallback binds that fabricate the tethys-53iv phantom
-    /// class. An edge with ANY trustworthy support survives.
-    pub fn get_callers(
-        &self,
-        qualified_name: &str,
-        exclude_speculative: bool,
-    ) -> Result<Vec<Dependent>> {
+    /// Indexed mode reads retained call edges with the requested
+    /// [`CallEdgeSelection`]. LSP-refined mode augments all indexed call edges
+    /// with language-server findings and deduplicates callers by symbol.
+    pub fn get_callers(&self, qualified_name: &str, mode: CallerMode) -> Result<Vec<Caller>> {
         let symbol = self
             .db
             .get_symbol_by_qualified_name(qualified_name)?
             .ok_or_else(|| Error::NotFound(format!("symbol: {qualified_name}")))?;
 
-        let callers = self.db.get_callers(symbol.id, exclude_speculative)?;
+        let callers = match mode {
+            CallerMode::Indexed { call_edges } => self.db.get_callers(symbol.id, call_edges)?,
+            CallerMode::LspRefined => self.get_lsp_refined_callers(qualified_name, &symbol)?,
+        };
 
-        self.convert_callers_to_dependents(callers)
+        Ok(callers.into_iter().map(|caller| caller.caller).collect())
     }
 
     /// Get symbols that the given symbol calls/uses.
@@ -488,9 +498,8 @@ impl Tethys {
             .db
             .get_transitive_callers(symbol.id, Some(depth), exclude_speculative)?;
 
-        let direct_dependents = self.convert_callers_to_dependents(impact.direct_callers)?;
-        let transitive_dependents =
-            self.convert_callers_to_dependents(impact.transitive_callers)?;
+        let direct_dependents = callers_to_dependents(impact.direct_callers);
+        let transitive_dependents = callers_to_dependents(impact.transitive_callers);
 
         let target_file = self
             .db
@@ -680,9 +689,9 @@ impl Tethys {
             |id| {
                 Ok(self
                     .db
-                    .get_callers(id, false)?
+                    .get_callers(id, CallEdgeSelection::All)?
                     .into_iter()
-                    .map(|c| c.symbol)
+                    .map(|c| c.caller.symbol)
                     .collect())
             },
             types::ReachabilityDirection::Backward,
@@ -1205,7 +1214,43 @@ mod arch_api_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use tempfile::TempDir;
+
+    static TRACED_CALLER_SQL: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+    fn collect_caller_sql(sql: &str) {
+        TRACED_CALLER_SQL
+            .lock()
+            .expect("caller SQL trace lock")
+            .push(sql.to_string());
+    }
+
+    fn traced_direct_callers(tethys: &Tethys, qualified_name: &str) -> (Vec<Caller>, Vec<String>) {
+        TRACED_CALLER_SQL
+            .lock()
+            .expect("caller SQL trace lock")
+            .clear();
+        {
+            let mut connection = tethys.db.connection().expect("index connection");
+            connection.trace(Some(collect_caller_sql));
+        }
+
+        let callers = tethys.get_callers(
+            qualified_name,
+            CallerMode::Indexed {
+                call_edges: CallEdgeSelection::All,
+            },
+        );
+
+        {
+            let mut connection = tethys.db.connection().expect("index connection");
+            connection.trace(None);
+        }
+        let statements =
+            std::mem::take(&mut *TRACED_CALLER_SQL.lock().expect("caller SQL trace lock"));
+        (callers.expect("direct caller query"), statements)
+    }
 
     fn temp_workspace() -> TempDir {
         tempfile::tempdir().expect("failed to create temp dir")
@@ -1342,6 +1387,54 @@ mod tests {
         assert!(
             stats.lsp_sessions.is_empty(),
             "LSP sessions should be empty when use_lsp is false"
+        );
+    }
+    #[test]
+    fn caller_hydration_statement_count_is_independent_of_result_count() {
+        let workspace = temp_workspace();
+        let src_dir = workspace.path().join("src");
+        std::fs::create_dir_all(&src_dir).expect("create src dir");
+        std::fs::write(
+            workspace.path().join("Cargo.toml"),
+            "[package]\nname = \"caller_trace\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .expect("write Cargo.toml");
+        std::fs::write(
+            src_dir.join("lib.rs"),
+            "pub fn one_target() {}\n\
+             pub fn many_target() {}\n\
+             pub fn one_caller() { one_target(); }\n\
+             pub fn many_a() { many_target(); }\n\
+             pub fn many_b() { many_target(); }\n\
+             pub fn many_c() { many_target(); }\n\
+             pub fn many_d() { many_target(); }\n",
+        )
+        .expect("write lib.rs");
+
+        let mut tethys = Tethys::new(workspace.path()).expect("create tethys");
+        tethys.index().expect("index");
+
+        let (one_caller, one_caller_sql) = traced_direct_callers(&tethys, "one_target");
+        let (many_callers, many_caller_sql) = traced_direct_callers(&tethys, "many_target");
+
+        assert_eq!(one_caller.len(), 1);
+        assert_eq!(many_callers.len(), 4);
+        assert_eq!(
+            one_caller_sql.len(),
+            2,
+            "target lookup plus one hydrated caller query"
+        );
+        assert_eq!(
+            many_caller_sql.len(),
+            one_caller_sql.len(),
+            "caller hydration must not add one statement per result"
+        );
+        assert!(
+            one_caller
+                .iter()
+                .chain(&many_callers)
+                .all(|caller| caller.file == Path::new("src/lib.rs")),
+            "hydrated callers must expose their workspace-relative indexed file"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ enum Commands {
         transitive: bool,
 
         /// Use LSP (rust-analyzer) for enhanced reference resolution
-        #[arg(long)]
+        #[arg(long, conflicts_with_all = ["transitive", "exclude_speculative"])]
         lsp: bool,
 
         /// Drop call edges whose every supporting reference was bound by

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1576,8 +1576,11 @@ mod memo_tests {
 /// `lsp_callers` integration tests).
 #[cfg(test)]
 mod lsp_caller_merge_tests {
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
+    #[cfg(not(windows))]
+    use std::path::PathBuf;
 
+    #[cfg(not(windows))]
     use crate::types::CallEdgeSelection;
 
     /// Fixture crate for the merge seam: `indexed_caller` produces a call
@@ -1613,6 +1616,7 @@ pub fn lsp_only_caller() -> bool {
 
     /// Zero-indexed (LSP convention) line of the first fixture line
     /// containing `marker`.
+    #[cfg(not(windows))]
     fn fixture_lsp_line(marker: &str) -> u32 {
         let line = MERGE_FIXTURE
             .lines()
@@ -1621,8 +1625,14 @@ pub fn lsp_only_caller() -> bool {
         u32::try_from(line).expect("fixture line fits u32")
     }
 
+    /// Build a `file://` URI for `path` the way LSP servers emit them:
+    /// forward slashes, no verbatim `\\?\` prefix, and a leading slash
+    /// before Windows drive letters.
     fn lsp_location_at(file: &Path, lsp_line: u32) -> lsp_types::Location {
-        let uri: lsp_types::Uri = format!("file://{}", file.display())
+        let display = file.display().to_string().replace('\\', "/");
+        let display = display.strip_prefix("//?/").unwrap_or(&display);
+        let slash = if display.starts_with('/') { "" } else { "/" };
+        let uri: lsp_types::Uri = format!("file://{slash}{display}")
             .parse()
             .expect("valid file URI");
         let position = lsp_types::Position::new(lsp_line, 4);
@@ -1636,6 +1646,12 @@ pub fn lsp_only_caller() -> bool {
     /// A reference overlapping an indexed caller must not duplicate it, and
     /// a reference inside a symbol the index reported no edge for must be
     /// added as a caller with the indexed file attached.
+    ///
+    /// Windows is excluded: attribution round-trips `uri_to_path` output
+    /// against the canonicalized workspace root, whose verbatim `\\?\`
+    /// prefix never matches a URI-derived path — Windows URI/path
+    /// hardening is tethys-w3z7 scope.
+    #[cfg(not(windows))]
     #[test]
     fn merge_lsp_reference_callers_dedups_overlap_and_adds_novel_caller() {
         let (dir, tethys) = caller_merge_fixture();
@@ -1695,8 +1711,9 @@ pub fn lsp_only_caller() -> bool {
         let workspace = dir.path().canonicalize().expect("canonical workspace");
 
         let outside = lsp_location_at(Path::new("/definitely/not/indexed.rs"), 0);
-        // Blank separator line between fixture functions: in-workspace but
-        // contained by no symbol span.
+        // Blank separator line between fixture functions: contained by no
+        // symbol span (on Windows the verbatim workspace root already makes
+        // it unattributable a step earlier — skipped either way).
         let uncontained = lsp_location_at(&workspace.join("src/lib.rs"), 3);
 
         let merged = tethys

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1194,11 +1194,6 @@ impl Tethys {
     ) -> Result<Vec<graph::CallerInfo>> {
         // Step 1: Get callers from the index
         let indexed_callers = self.db.get_callers(symbol.id, CallEdgeSelection::All)?;
-        // Build a set of symbol IDs we already know about
-        let mut known_symbol_ids: HashSet<SymbolId> = indexed_callers
-            .iter()
-            .map(|caller| caller.caller.symbol.id)
-            .collect();
 
         // Step 2: Get the symbol's definition file path
         let symbol_file = self
@@ -1241,14 +1236,42 @@ impl Tethys {
             warn!(error = %e, "LSP shutdown failed");
         }
 
+        let indexed_len = indexed_callers.len();
         debug!(
             symbol = %qualified_name,
-            indexed_callers = indexed_callers.len(),
+            indexed_callers = indexed_len,
             lsp_refs = lsp_refs.len(),
             "Merging indexed and LSP caller results"
         );
 
-        // Step 4: For each LSP reference, find its containing symbol
+        // Steps 4-5: resolve references to containing symbols and merge
+        let merged = self.merge_lsp_reference_callers(indexed_callers, lsp_refs)?;
+
+        info!(
+            symbol = %qualified_name,
+            indexed_callers = indexed_len,
+            lsp_additional = merged.len() - indexed_len,
+            "Caller merge complete"
+        );
+        Ok(merged)
+    }
+
+    /// Merge LSP reference locations into indexed caller findings.
+    ///
+    /// Resolves each location to its innermost containing indexed symbol and
+    /// appends callers the index did not already report, deduplicating by
+    /// caller symbol id. Locations outside the workspace or absent from the
+    /// index are skipped.
+    pub(crate) fn merge_lsp_reference_callers(
+        &self,
+        indexed_callers: Vec<graph::CallerInfo>,
+        lsp_refs: Vec<lsp_types::Location>,
+    ) -> Result<Vec<graph::CallerInfo>> {
+        // Symbol IDs the index already reported.
+        let mut known_symbol_ids: HashSet<SymbolId> = indexed_callers
+            .iter()
+            .map(|caller| caller.caller.symbol.id)
+            .collect();
         let mut additional_callers: Vec<graph::CallerInfo> = Vec::new();
 
         for loc in lsp_refs {
@@ -1309,14 +1332,6 @@ impl Tethys {
             });
         }
 
-        info!(
-            symbol = %qualified_name,
-            indexed_callers = indexed_callers.len(),
-            lsp_additional = additional_callers.len(),
-            "Caller merge complete"
-        );
-
-        // Step 5: Combine indexed and LSP callers
         Ok(indexed_callers
             .into_iter()
             .chain(additional_callers)
@@ -1552,5 +1567,144 @@ mod memo_tests {
                 "unknown name at line {line} must remain unresolved"
             );
         }
+    }
+}
+
+/// CI-safe fences for [`Tethys::merge_lsp_reference_callers`]: the merge and
+/// dedup behavior is exercised with fabricated LSP locations, so no language
+/// server is required (the real-server path stays in the ignored
+/// `lsp_callers` integration tests).
+#[cfg(test)]
+mod lsp_caller_merge_tests {
+    use std::path::{Path, PathBuf};
+
+    use crate::types::CallEdgeSelection;
+
+    /// Fixture crate for the merge seam: `indexed_caller` produces a call
+    /// edge to `target`; `lsp_only_caller` never calls it, so only a
+    /// fabricated LSP reference can surface it as a caller.
+    const MERGE_FIXTURE: &str = "\
+pub fn target() -> bool {
+    true
+}
+
+pub fn indexed_caller() -> bool {
+    target() // indexed call site
+}
+
+pub fn lsp_only_caller() -> bool {
+    true // lsp-only reference site
+}
+";
+
+    fn caller_merge_fixture() -> (tempfile::TempDir, crate::Tethys) {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        std::fs::create_dir_all(dir.path().join("src")).expect("create src dir");
+        std::fs::write(dir.path().join("src/lib.rs"), MERGE_FIXTURE).expect("write lib.rs");
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"merge_fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .expect("write Cargo.toml");
+        let mut tethys = crate::Tethys::new(dir.path()).expect("create Tethys");
+        tethys.index().expect("index fixture");
+        (dir, tethys)
+    }
+
+    /// Zero-indexed (LSP convention) line of the first fixture line
+    /// containing `marker`.
+    fn fixture_lsp_line(marker: &str) -> u32 {
+        let line = MERGE_FIXTURE
+            .lines()
+            .position(|line| line.contains(marker))
+            .expect("marker present in fixture");
+        u32::try_from(line).expect("fixture line fits u32")
+    }
+
+    fn lsp_location_at(file: &Path, lsp_line: u32) -> lsp_types::Location {
+        let uri: lsp_types::Uri = format!("file://{}", file.display())
+            .parse()
+            .expect("valid file URI");
+        let position = lsp_types::Position::new(lsp_line, 4);
+        lsp_types::Location {
+            uri,
+            range: lsp_types::Range::new(position, position),
+        }
+    }
+
+    /// CI-safe fence for the LSP caller merge: no language server involved.
+    /// A reference overlapping an indexed caller must not duplicate it, and
+    /// a reference inside a symbol the index reported no edge for must be
+    /// added as a caller with the indexed file attached.
+    #[test]
+    fn merge_lsp_reference_callers_dedups_overlap_and_adds_novel_caller() {
+        let (dir, tethys) = caller_merge_fixture();
+        let workspace = dir.path().canonicalize().expect("canonical workspace");
+        let lib_rs = workspace.join("src/lib.rs");
+
+        let symbol = tethys
+            .db
+            .get_symbol_by_qualified_name("target")
+            .expect("symbol query")
+            .expect("target symbol indexed");
+        let indexed = tethys
+            .db
+            .get_callers(symbol.id, CallEdgeSelection::All)
+            .expect("indexed callers");
+        let indexed_names: Vec<_> = indexed
+            .iter()
+            .map(|info| info.caller.symbol.name.clone())
+            .collect();
+        assert_eq!(
+            indexed_names,
+            ["indexed_caller"],
+            "fixture precondition: the index reports exactly the direct caller"
+        );
+
+        let overlap = lsp_location_at(&lib_rs, fixture_lsp_line("indexed call site"));
+        let novel = lsp_location_at(&lib_rs, fixture_lsp_line("lsp-only reference site"));
+
+        let merged = tethys
+            .merge_lsp_reference_callers(indexed, vec![overlap, novel])
+            .expect("merge succeeds");
+
+        let mut merged_names: Vec<_> = merged
+            .iter()
+            .map(|info| info.caller.symbol.name.clone())
+            .collect();
+        merged_names.sort_unstable();
+        assert_eq!(
+            merged_names,
+            ["indexed_caller", "lsp_only_caller"],
+            "overlapping reference deduplicated, novel caller added exactly once"
+        );
+
+        let lsp_only = merged
+            .iter()
+            .find(|info| info.caller.symbol.name == "lsp_only_caller")
+            .expect("lsp-only caller present");
+        assert_eq!(lsp_only.reference_count, 1);
+        assert_eq!(lsp_only.caller.file, PathBuf::from("src/lib.rs"));
+    }
+
+    /// References the merge cannot attribute — outside the workspace or on a
+    /// line no indexed symbol contains — are skipped, not errors.
+    #[test]
+    fn merge_lsp_reference_callers_skips_unattributable_references() {
+        let (dir, tethys) = caller_merge_fixture();
+        let workspace = dir.path().canonicalize().expect("canonical workspace");
+
+        let outside = lsp_location_at(Path::new("/definitely/not/indexed.rs"), 0);
+        // Blank separator line between fixture functions: in-workspace but
+        // contained by no symbol span.
+        let uncontained = lsp_location_at(&workspace.join("src/lib.rs"), 3);
+
+        let merged = tethys
+            .merge_lsp_reference_callers(Vec::new(), vec![outside, uncontained])
+            .expect("merge succeeds");
+        assert!(
+            merged.is_empty(),
+            "unattributable references must be skipped: {merged:?}"
+        );
     }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -13,14 +13,15 @@ use tracing::{debug, info, trace, warn};
 use crate::Tethys;
 use crate::error::{Error, Result};
 use crate::graph;
+use crate::languages::get_language_support;
 use crate::languages::module_resolver::{
     GlobPolicy, ModuleContext, ModuleResolver, NamespaceMap, get_module_resolver,
 };
 use crate::lsp::{self, LspProvider};
 use crate::types::{
-    Dependent, FileId, Import, Language, LspCompletedSession, LspOutcome, LspSessionResult,
-    Reference, ReferenceKind, ResolutionStrategy, Symbol, SymbolId, SymbolKind,
-    UnresolvedRefForLsp,
+    CallEdgeSelection, Caller, DEFAULT_LSP_TIMEOUT_SECS, FileId, Import, Language,
+    LspCompletedSession, LspOutcome, LspSessionResult, Reference, ReferenceKind,
+    ResolutionStrategy, Symbol, SymbolId, SymbolKind, UnresolvedRefForLsp,
 };
 
 /// Whether a reference of `ref_kind` is allowed to bind to a symbol of
@@ -74,10 +75,6 @@ pub(crate) struct ResolveContext<'a> {
     pub(crate) module_ctx: &'a ModuleContext<'a>,
 }
 
-#[expect(
-    clippy::missing_errors_doc,
-    reason = "error docs deferred to avoid churn during active development"
-)]
 impl Tethys {
     /// Resolve cross-file references against the symbol database (Pass 2).
     ///
@@ -1099,42 +1096,109 @@ impl Tethys {
         }
     }
 
+    /// Locate the declared identifier for an LSP position.
+    ///
+    /// Indexed symbol coordinates point at the declaration node, while
+    /// `textDocument/references` must target its `name` field. Falls back to
+    /// the indexed coordinates when no syntax span or source is available.
+    fn lsp_symbol_name_position(file: &Path, symbol: &Symbol, language: Language) -> (u32, u32) {
+        let fallback = (
+            symbol.line.saturating_sub(1),
+            symbol.column.saturating_sub(1),
+        );
+        let Some(span) = symbol.span else {
+            return fallback;
+        };
+        let Ok(source) = std::fs::read(file) else {
+            return fallback;
+        };
+        get_language_support(language)
+            .definition_name_position(&source, span)
+            .map_or(fallback, |(line, column)| {
+                (line.saturating_sub(1), column.saturating_sub(1))
+            })
+    }
+
+    /// Start an LSP client and wait for its provider-specific readiness signal.
+    fn start_ready_caller_lsp(
+        &self,
+        provider: lsp::AnyProvider,
+        symbol_name: &str,
+        language: Language,
+    ) -> Option<lsp::LspClient> {
+        let mut client = match lsp::LspClient::start(&provider, &self.workspace_root) {
+            Ok(client) => client,
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    symbol = %symbol_name,
+                    ?language,
+                    install_hint = %provider.install_hint(),
+                    "LSP server failed to start — returning indexed callers only \
+                     (results may be incomplete). {} Or remove --lsp.",
+                    provider.install_hint()
+                );
+                return None;
+            }
+        };
+
+        let timeout = std::time::Duration::from_secs(DEFAULT_LSP_TIMEOUT_SECS);
+        let ready = match client.wait_until_ready(provider.readiness_wait(), timeout) {
+            Ok(ready) => ready,
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    symbol = %symbol_name,
+                    "LSP readiness check failed"
+                );
+                false
+            }
+        };
+        if ready {
+            return Some(client);
+        }
+
+        warn!(
+            symbol = %symbol_name,
+            timeout_secs = DEFAULT_LSP_TIMEOUT_SECS,
+            "LSP server was not ready — returning indexed callers only"
+        );
+        if let Err(error) = client.shutdown() {
+            warn!(error = %error, "LSP shutdown failed");
+        }
+        None
+    }
+
     /// Get symbols that call/use the given symbol, with LSP refinement.
     ///
     /// Combines results from the tree-sitter index with references found by the
-    /// language server. This catches callers that tree-sitter couldn't resolve
+    /// language server. This catches callers that tree-sitter could not resolve
     /// during indexing (e.g., through complex type inference).
     ///
     /// # Design
     ///
-    /// 1. Get callers from the database (tree-sitter indexed)
+    /// 1. Get callers from the index
     /// 2. Find the symbol's definition location
     /// 3. Call LSP `find_references` at that location
     /// 4. For each LSP reference, find its containing symbol
-    /// 5. Merge with DB callers, deduplicating by symbol ID
+    /// 5. Merge with indexed callers, deduplicating by symbol ID
     ///
     /// # Fallback Behavior
     ///
-    /// If LSP fails to start or returns errors, falls back to DB-only results
+    /// If LSP fails to start or returns errors, falls back to indexed results
     /// and logs a warning.
-    #[expect(
-        clippy::too_many_lines,
-        reason = "combines DB lookup with LSP refinement in a single user-facing method"
-    )]
-    pub fn get_callers_with_lsp(&self, qualified_name: &str) -> Result<Vec<Dependent>> {
-        use std::collections::HashSet;
-
-        // Step 1: Get callers from the database
-        let symbol = self
-            .db
-            .get_symbol_by_qualified_name(qualified_name)?
-            .ok_or_else(|| Error::NotFound(format!("symbol: {qualified_name}")))?;
-
-        let db_callers = self.db.get_callers(symbol.id, false)?;
-
+    pub(crate) fn get_lsp_refined_callers(
+        &self,
+        qualified_name: &str,
+        symbol: &Symbol,
+    ) -> Result<Vec<graph::CallerInfo>> {
+        // Step 1: Get callers from the index
+        let indexed_callers = self.db.get_callers(symbol.id, CallEdgeSelection::All)?;
         // Build a set of symbol IDs we already know about
-        let mut known_symbol_ids: HashSet<SymbolId> =
-            db_callers.iter().map(|c| c.symbol.id).collect();
+        let mut known_symbol_ids: HashSet<SymbolId> = indexed_callers
+            .iter()
+            .map(|caller| caller.caller.symbol.id)
+            .collect();
 
         // Step 2: Get the symbol's definition file path
         let symbol_file = self
@@ -1146,27 +1210,15 @@ impl Tethys {
         // Step 3: Spawn LSP and call find_references
         // Select the appropriate LSP provider based on the symbol's file language
         let provider = lsp::AnyProvider::for_language(symbol_file.language);
-        let mut lsp_client = match lsp::LspClient::start(&provider, &self.workspace_root) {
-            Ok(client) => client,
-            Err(e) => {
-                // User explicitly requested --lsp, so log at warn level.
-                // Results will be incomplete: only tree-sitter-indexed callers are returned.
-                warn!(
-                    error = %e,
-                    symbol = %qualified_name,
-                    language = ?symbol_file.language,
-                    install_hint = %provider.install_hint(),
-                    "LSP server failed to start — returning DB-only callers \
-                     (results may be incomplete). {} Or remove --lsp flag.",
-                    provider.install_hint()
-                );
-                return self.convert_callers_to_dependents(db_callers);
-            }
+        let Some(mut lsp_client) =
+            self.start_ready_caller_lsp(provider, qualified_name, symbol_file.language)
+        else {
+            return Ok(indexed_callers);
         };
 
         // LSP uses 0-indexed positions, our DB uses 1-indexed
-        let lsp_line = symbol.line.saturating_sub(1);
-        let lsp_col = symbol.column.saturating_sub(1);
+        let (lsp_line, lsp_col) =
+            Self::lsp_symbol_name_position(&symbol_file_path, symbol, symbol_file.language);
 
         let lsp_refs = match lsp_client.find_references(&symbol_file_path, lsp_line, lsp_col) {
             Ok(refs) => refs,
@@ -1175,12 +1227,12 @@ impl Tethys {
                 tracing::error!(
                     error = %e,
                     symbol = %qualified_name,
-                    "LSP find_references failed - returning DB-only callers"
+                    "LSP find_references failed - returning indexed callers only"
                 );
                 if let Err(shutdown_err) = lsp_client.shutdown() {
                     warn!(error = %shutdown_err, "LSP shutdown failed");
                 }
-                return self.convert_callers_to_dependents(db_callers);
+                return Ok(indexed_callers);
             }
         };
 
@@ -1191,9 +1243,9 @@ impl Tethys {
 
         debug!(
             symbol = %qualified_name,
-            db_callers = db_callers.len(),
+            indexed_callers = indexed_callers.len(),
             lsp_refs = lsp_refs.len(),
-            "Merging DB and LSP caller results"
+            "Merging indexed and LSP caller results"
         );
 
         // Step 4: For each LSP reference, find its containing symbol
@@ -1230,7 +1282,8 @@ impl Tethys {
             let ref_line = loc.range.start.line + 1;
 
             // Find the symbol that contains this reference location
-            let Some(containing_symbol) = self.db.find_symbol_at_line(ref_file_id, ref_line)?
+            let Some(containing_symbol) =
+                self.db.find_symbol_containing_line(ref_file_id, ref_line)?
             else {
                 trace!(
                     ref_path = %relative_ref_path.display(),
@@ -1240,52 +1293,34 @@ impl Tethys {
                 continue;
             };
 
-            // Skip if we already have this caller from the DB
+            // Skip if the index already reported this caller.
             if known_symbol_ids.contains(&containing_symbol.id) {
                 continue;
             }
 
-            // Add this as a new caller
+            // Add a caller found only through LSP refinement.
             known_symbol_ids.insert(containing_symbol.id);
             additional_callers.push(graph::CallerInfo {
-                symbol: containing_symbol,
+                caller: Caller {
+                    symbol: containing_symbol,
+                    file: crate::db::normalize_path(relative_ref_path).into(),
+                },
                 reference_count: 1,
             });
         }
 
         info!(
             symbol = %qualified_name,
-            db_callers = db_callers.len(),
+            indexed_callers = indexed_callers.len(),
             lsp_additional = additional_callers.len(),
             "Caller merge complete"
         );
 
-        // Step 5: Combine DB and LSP callers and convert to Dependent
-        let all_callers: Vec<graph::CallerInfo> =
-            db_callers.into_iter().chain(additional_callers).collect();
-
-        self.convert_callers_to_dependents(all_callers)
-    }
-
-    /// Convert a list of `CallerInfo` to `Dependent` for the crate-internal API.
-    pub(crate) fn convert_callers_to_dependents(
-        &self,
-        callers: Vec<graph::CallerInfo>,
-    ) -> Result<Vec<Dependent>> {
-        callers
+        // Step 5: Combine indexed and LSP callers
+        Ok(indexed_callers
             .into_iter()
-            .map(|c| {
-                let file = self
-                    .db
-                    .get_file_by_id(c.symbol.file_id)?
-                    .ok_or_else(|| Error::NotFound(format!("file id: {}", c.symbol.file_id)))?;
-                Ok(Dependent {
-                    file: file.path,
-                    symbols_used: vec![c.symbol.qualified_name],
-                    line_count: c.reference_count,
-                })
-            })
-            .collect()
+            .chain(additional_callers)
+            .collect())
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1258,6 +1258,36 @@ impl StalenessReport {
     }
 }
 
+/// Which retained call edges an indexed caller query should include.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallEdgeSelection {
+    /// Include every retained call edge.
+    All,
+    /// Exclude edges whose every supporting reference is speculative.
+    ExcludeSpeculative,
+}
+
+/// How a direct caller query should discover callers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CallerMode {
+    /// Query retained call edges from the index.
+    Indexed {
+        /// Which retained call edges to include.
+        call_edges: CallEdgeSelection,
+    },
+    /// Augment indexed call edges with callers reported by the language server.
+    LspRefined,
+}
+
+/// A symbol that directly calls another symbol.
+#[derive(Debug, Clone)]
+pub struct Caller {
+    /// The calling symbol.
+    pub symbol: Symbol,
+    /// Workspace-relative path of the indexed file containing the caller.
+    pub file: PathBuf,
+}
+
 /// Result of impact analysis.
 ///
 /// Shows which files/symbols would be affected by changes to a target.

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -7,7 +7,7 @@
 
 use std::fs;
 use tempfile::TempDir;
-use tethys::Tethys;
+use tethys::{CallEdgeSelection, CallerMode, Tethys};
 
 /// Create a workspace with a known dependency structure for testing.
 ///
@@ -711,7 +711,12 @@ fn get_callers_returns_error_for_nonexistent_symbol() {
     let (_dir, mut tethys) = workspace_with_call_graph();
     tethys.index().expect("index failed");
 
-    let result = tethys.get_callers("NonExistent", false);
+    let result = tethys.get_callers(
+        "NonExistent",
+        tethys::CallerMode::Indexed {
+            call_edges: tethys::CallEdgeSelection::All,
+        },
+    );
 
     assert!(
         result.is_err(),
@@ -731,7 +736,12 @@ fn get_callers_returns_empty_for_uncalled_symbol() {
 
     // process is the top-level function - nothing calls it
     let callers = tethys
-        .get_callers("process", false)
+        .get_callers(
+            "process",
+            tethys::CallerMode::Indexed {
+                call_edges: tethys::CallEdgeSelection::All,
+            },
+        )
         .expect("get_callers for process should succeed");
 
     assert!(
@@ -741,18 +751,25 @@ fn get_callers_returns_empty_for_uncalled_symbol() {
 }
 
 #[test]
-fn get_callers_finds_intra_file_callers() {
+fn get_callers_returns_caller_symbol_and_indexed_file() {
     let (_dir, mut tethys) = workspace_with_intra_file_calls();
     tethys.index().expect("index failed");
 
-    // validate is called by process
     let callers = tethys
-        .get_callers("validate", false)
+        .get_callers(
+            "validate",
+            CallerMode::Indexed {
+                call_edges: CallEdgeSelection::All,
+            },
+        )
         .expect("get_callers for validate should succeed");
 
+    assert_eq!(callers.len(), 1, "validate has one direct caller");
+    assert_eq!(callers[0].symbol.qualified_name, "process");
+    assert_eq!(callers[0].file.to_string_lossy(), "src/lib.rs");
     assert!(
-        !callers.is_empty(),
-        "validate should have at least one caller (process)"
+        !callers[0].symbol.is_test,
+        "a non-test caller must not inherit call-count evidence as is_test"
     );
 }
 
@@ -764,7 +781,12 @@ fn get_callers_cross_file_refs_resolved() {
     // Connection is referenced from other files via `use crate::db::Connection`,
     // Cross-file references are now resolved in Pass 2.
     let callers = tethys
-        .get_callers("Connection", false)
+        .get_callers(
+            "Connection",
+            tethys::CallerMode::Indexed {
+                call_edges: tethys::CallEdgeSelection::All,
+            },
+        )
         .expect("get_callers for Connection should succeed");
 
     assert!(
@@ -946,7 +968,12 @@ fn call_edges_populated_after_indexing() {
 
     // validate is called by process
     let callers = tethys
-        .get_callers("validate", false)
+        .get_callers(
+            "validate",
+            tethys::CallerMode::Indexed {
+                call_edges: tethys::CallEdgeSelection::All,
+            },
+        )
         .expect("get_callers for validate should succeed");
 
     assert!(
@@ -954,10 +981,9 @@ fn call_edges_populated_after_indexing() {
         "validate should have callers via call_edges"
     );
 
-    // Verify the caller contains "process" in symbols_used
     let all_symbols: Vec<&str> = callers
         .iter()
-        .flat_map(|c| c.symbols_used.iter().map(String::as_str))
+        .map(|caller| caller.symbol.qualified_name.as_str())
         .collect();
     assert!(
         all_symbols.iter().any(|n| n.contains("process")),
@@ -1004,7 +1030,12 @@ namespace App
     tethys.index().expect("index failed");
 
     let helper_callers = tethys
-        .get_callers("Widget::Helper", false)
+        .get_callers(
+            "Widget::Helper",
+            tethys::CallerMode::Indexed {
+                call_edges: tethys::CallEdgeSelection::All,
+            },
+        )
         .expect("get_callers for Widget::Helper should succeed");
     assert!(
         !helper_callers.is_empty(),
@@ -1012,7 +1043,12 @@ namespace App
     );
 
     let data_callers = tethys
-        .get_callers("Widget::Data", false)
+        .get_callers(
+            "Widget::Data",
+            tethys::CallerMode::Indexed {
+                call_edges: tethys::CallEdgeSelection::All,
+            },
+        )
         .expect("get_callers for Widget::Data should succeed");
     assert!(
         data_callers.is_empty(),
@@ -1056,7 +1092,12 @@ namespace App
     tethys.index().expect("index failed");
 
     let property_callers = tethys
-        .get_callers("StepFailed::Exception", false)
+        .get_callers(
+            "StepFailed::Exception",
+            tethys::CallerMode::Indexed {
+                call_edges: tethys::CallEdgeSelection::All,
+            },
+        )
         .expect("get_callers for the Exception property should succeed");
     assert!(
         property_callers.is_empty(),

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -713,8 +713,8 @@ fn get_callers_returns_error_for_nonexistent_symbol() {
 
     let result = tethys.get_callers(
         "NonExistent",
-        tethys::CallerMode::Indexed {
-            call_edges: tethys::CallEdgeSelection::All,
+        CallerMode::Indexed {
+            call_edges: CallEdgeSelection::All,
         },
     );
 
@@ -738,8 +738,8 @@ fn get_callers_returns_empty_for_uncalled_symbol() {
     let callers = tethys
         .get_callers(
             "process",
-            tethys::CallerMode::Indexed {
-                call_edges: tethys::CallEdgeSelection::All,
+            CallerMode::Indexed {
+                call_edges: CallEdgeSelection::All,
             },
         )
         .expect("get_callers for process should succeed");
@@ -783,8 +783,8 @@ fn get_callers_cross_file_refs_resolved() {
     let callers = tethys
         .get_callers(
             "Connection",
-            tethys::CallerMode::Indexed {
-                call_edges: tethys::CallEdgeSelection::All,
+            CallerMode::Indexed {
+                call_edges: CallEdgeSelection::All,
             },
         )
         .expect("get_callers for Connection should succeed");
@@ -970,8 +970,8 @@ fn call_edges_populated_after_indexing() {
     let callers = tethys
         .get_callers(
             "validate",
-            tethys::CallerMode::Indexed {
-                call_edges: tethys::CallEdgeSelection::All,
+            CallerMode::Indexed {
+                call_edges: CallEdgeSelection::All,
             },
         )
         .expect("get_callers for validate should succeed");
@@ -1032,8 +1032,8 @@ namespace App
     let helper_callers = tethys
         .get_callers(
             "Widget::Helper",
-            tethys::CallerMode::Indexed {
-                call_edges: tethys::CallEdgeSelection::All,
+            CallerMode::Indexed {
+                call_edges: CallEdgeSelection::All,
             },
         )
         .expect("get_callers for Widget::Helper should succeed");
@@ -1045,8 +1045,8 @@ namespace App
     let data_callers = tethys
         .get_callers(
             "Widget::Data",
-            tethys::CallerMode::Indexed {
-                call_edges: tethys::CallEdgeSelection::All,
+            CallerMode::Indexed {
+                call_edges: CallEdgeSelection::All,
             },
         )
         .expect("get_callers for Widget::Data should succeed");
@@ -1094,8 +1094,8 @@ namespace App
     let property_callers = tethys
         .get_callers(
             "StepFailed::Exception",
-            tethys::CallerMode::Indexed {
-                call_edges: tethys::CallEdgeSelection::All,
+            CallerMode::Indexed {
+                call_edges: CallEdgeSelection::All,
             },
         )
         .expect("get_callers for the Exception property should succeed");

--- a/tests/lsp_callers.rs
+++ b/tests/lsp_callers.rs
@@ -1,8 +1,7 @@
-//! Integration tests for `get_callers_with_lsp` functionality.
+//! Integration tests for LSP-refined direct caller queries.
 //!
-//! These tests verify that LSP-augmented caller detection works correctly:
-//! - Graceful fallback when LSP is not available
-//! - Proper merging of DB and LSP results (when LSP is available)
+//! These tests verify graceful fallback, indexed/LSP merging, and
+//! deduplication through [`tethys::CallerMode::LspRefined`].
 //!
 //! Tests marked with `#[ignore]` require rust-analyzer to be installed.
 //! Run with: `cargo test --test lsp_callers -- --ignored`
@@ -82,15 +81,15 @@ edition = "2021"
 // ============================================================================
 
 #[test]
-fn get_callers_with_lsp_returns_db_callers_when_lsp_unavailable() {
+fn lsp_refined_mode_includes_indexed_callers() {
     let (_dir, mut tethys) = workspace_with_intra_file_calls();
     tethys.index().expect("index failed");
 
     // Even if LSP fails, should return DB callers gracefully
     // validate is called by process
     let callers = tethys
-        .get_callers_with_lsp("validate")
-        .expect("get_callers_with_lsp should succeed even without LSP");
+        .get_callers("validate", tethys::CallerMode::LspRefined)
+        .expect("LSP-refined caller query should succeed");
 
     // Should have at least the DB callers
     assert!(
@@ -100,11 +99,11 @@ fn get_callers_with_lsp_returns_db_callers_when_lsp_unavailable() {
 }
 
 #[test]
-fn get_callers_with_lsp_returns_error_for_nonexistent_symbol() {
+fn lsp_refined_mode_returns_error_for_nonexistent_symbol() {
     let (_dir, mut tethys) = workspace_with_intra_file_calls();
     tethys.index().expect("index failed");
 
-    let result = tethys.get_callers_with_lsp("NonExistent");
+    let result = tethys.get_callers("NonExistent", tethys::CallerMode::LspRefined);
 
     assert!(
         result.is_err(),
@@ -118,14 +117,14 @@ fn get_callers_with_lsp_returns_error_for_nonexistent_symbol() {
 }
 
 #[test]
-fn get_callers_with_lsp_returns_empty_for_uncalled_symbol() {
+fn lsp_refined_mode_returns_empty_for_uncalled_symbol() {
     let (_dir, mut tethys) = workspace_with_intra_file_calls();
     tethys.index().expect("index failed");
 
     // process is never called
     let callers = tethys
-        .get_callers_with_lsp("process")
-        .expect("get_callers_with_lsp should succeed");
+        .get_callers("process", tethys::CallerMode::LspRefined)
+        .expect("LSP-refined caller query should succeed");
 
     assert!(
         callers.is_empty(),
@@ -134,17 +133,22 @@ fn get_callers_with_lsp_returns_empty_for_uncalled_symbol() {
 }
 
 #[test]
-fn get_callers_with_lsp_matches_get_callers_baseline() {
+fn lsp_refined_mode_includes_indexed_baseline() {
     let (_dir, mut tethys) = workspace_with_intra_file_calls();
     tethys.index().expect("index failed");
 
-    // get_callers_with_lsp should return at least what get_callers returns
+    // LSP refinement must retain every indexed caller.
     let db_callers = tethys
-        .get_callers("validate", false)
+        .get_callers(
+            "validate",
+            tethys::CallerMode::Indexed {
+                call_edges: tethys::CallEdgeSelection::All,
+            },
+        )
         .expect("get_callers failed");
     let lsp_callers = tethys
-        .get_callers_with_lsp("validate")
-        .expect("get_callers_with_lsp failed");
+        .get_callers("validate", tethys::CallerMode::LspRefined)
+        .expect("LSP-refined caller query failed");
 
     // LSP version should have >= DB version (may have additional from LSP)
     assert!(
@@ -161,34 +165,7 @@ fn get_callers_with_lsp_matches_get_callers_baseline() {
 
 #[test]
 #[ignore = "requires rust-analyzer installed"]
-fn get_callers_with_lsp_merges_lsp_results() {
-    if !rust_analyzer_available() {
-        eprintln!("Skipping test: rust-analyzer not available");
-        return;
-    }
-
-    let (_dir, mut tethys) = workspace_with_intra_file_calls();
-    tethys.index().expect("index failed");
-
-    // With LSP, we may find additional callers
-    let callers = tethys
-        .get_callers_with_lsp("validate")
-        .expect("get_callers_with_lsp should succeed");
-
-    // Should have at least one caller (process)
-    assert!(
-        !callers.is_empty(),
-        "validate should have callers: {callers:?}"
-    );
-}
-
-/// Test that cross-file references can be found via LSP that tree-sitter might miss.
-///
-/// This test creates a workspace where a function uses a type from another file,
-/// which tree-sitter might not fully resolve but LSP can.
-#[test]
-#[ignore = "requires rust-analyzer installed"]
-fn get_callers_with_lsp_finds_cross_file_callers() {
+fn lsp_refined_mode_adds_semantic_caller_and_deduplicates_overlap() {
     if !rust_analyzer_available() {
         eprintln!("Skipping test: rust-analyzer not available");
         return;
@@ -196,62 +173,76 @@ fn get_callers_with_lsp_finds_cross_file_callers() {
 
     let dir = tempfile::tempdir().expect("failed to create temp dir");
     fs::create_dir_all(dir.path().join("src")).expect("failed to create src dir");
-
-    // Create a multi-file workspace
+    fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"lsp_caller_merge\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+    )
+    .expect("write Cargo.toml");
     fs::write(
         dir.path().join("src/lib.rs"),
         r"
-mod helper;
-mod caller;
-",
-    )
-    .expect("failed to write lib.rs");
+pub struct Worker;
 
-    fs::write(
-        dir.path().join("src/helper.rs"),
-        r"
-pub fn do_work() -> i32 {
-    42
+impl Worker {
+    pub fn run(&self) {}
+
+    pub fn indexed_caller(&self) {
+        self.run();
+    }
+}
+
+pub struct Decoy;
+
+impl Decoy {
+    pub fn run(&self) {}
+}
+
+pub fn make_worker() -> Worker {
+    Worker
+}
+
+
+pub fn inferred_caller() {
+    make_worker().run();
 }
 ",
     )
-    .expect("failed to write helper.rs");
+    .expect("write lib.rs");
 
-    fs::write(
-        dir.path().join("src/caller.rs"),
-        r"
-use crate::helper::do_work;
-
-pub fn call_helper() -> i32 {
-    do_work()
-}
-",
-    )
-    .expect("failed to write caller.rs");
-
-    fs::write(
-        dir.path().join("Cargo.toml"),
-        r#"
-[package]
-name = "test_workspace"
-version = "0.1.0"
-edition = "2021"
-"#,
-    )
-    .expect("failed to write Cargo.toml");
-
-    let mut tethys = Tethys::new(dir.path()).expect("failed to create Tethys");
+    let mut tethys = Tethys::new(dir.path()).expect("create Tethys");
     tethys.index().expect("index failed");
 
-    // With LSP, should find that call_helper calls do_work
-    let callers = tethys
-        .get_callers_with_lsp("do_work")
-        .expect("get_callers_with_lsp should succeed");
+    let indexed = tethys
+        .get_callers(
+            "Worker::run",
+            tethys::CallerMode::Indexed {
+                call_edges: tethys::CallEdgeSelection::All,
+            },
+        )
+        .expect("indexed caller query");
+    let mut indexed_names: Vec<_> = indexed
+        .iter()
+        .map(|caller| caller.symbol.qualified_name.as_str())
+        .collect();
+    indexed_names.sort_unstable();
+    assert_eq!(
+        indexed_names,
+        ["Worker::indexed_caller"],
+        "the ambiguous inferred receiver must be absent before LSP refinement"
+    );
 
-    // LSP should help find the cross-file caller
-    assert!(
-        !callers.is_empty(),
-        "do_work should have callers (call_helper), got: {callers:?}"
+    let refined = tethys
+        .get_callers("Worker::run", tethys::CallerMode::LspRefined)
+        .expect("LSP-refined caller query");
+    let mut refined_names: Vec<_> = refined
+        .iter()
+        .map(|caller| caller.symbol.qualified_name.as_str())
+        .collect();
+    refined_names.sort_unstable();
+    assert_eq!(
+        refined_names,
+        ["Worker::indexed_caller", "inferred_caller"],
+        "LSP must add the inferred caller while retaining the indexed overlap exactly once"
     );
 }
 
@@ -260,21 +251,20 @@ edition = "2021"
 // ============================================================================
 
 #[test]
-fn get_callers_with_lsp_does_not_duplicate_callers() {
+fn lsp_refined_mode_deduplicates_caller_symbols() {
     let (_dir, mut tethys) = workspace_with_intra_file_calls();
     tethys.index().expect("index failed");
 
     let callers = tethys
-        .get_callers_with_lsp("validate")
-        .expect("get_callers_with_lsp should succeed");
+        .get_callers("validate", tethys::CallerMode::LspRefined)
+        .expect("LSP-refined caller query should succeed");
 
-    // Check for duplicates by qualified name
-    let caller_names: Vec<_> = callers.iter().map(|c| &c.symbols_used).collect();
-    let unique_names: std::collections::HashSet<_> = caller_names.iter().collect();
+    let caller_ids: Vec<_> = callers.iter().map(|caller| caller.symbol.id).collect();
+    let unique_ids: std::collections::HashSet<_> = caller_ids.iter().collect();
 
     assert_eq!(
-        caller_names.len(),
-        unique_names.len(),
-        "should not have duplicate callers: {caller_names:?}"
+        caller_ids.len(),
+        unique_ids.len(),
+        "should not have duplicate caller symbols: {caller_ids:?}"
     );
 }

--- a/tests/lsp_resolution.rs
+++ b/tests/lsp_resolution.rs
@@ -105,7 +105,7 @@ pub fn use_data_processor() -> i32 {
     // Verify we can query callers for the trait method
     // This tests that LSP helped resolve the trait method call
     let callers = tethys
-        .get_callers_with_lsp("run_processor")
+        .get_callers("run_processor", tethys::CallerMode::LspRefined)
         .expect("get_callers failed");
 
     assert!(
@@ -181,7 +181,7 @@ pub fn chain_inference() -> Option<i32> {
 
     // Check that create_data has callers (process_data and chain_inference)
     let callers = tethys
-        .get_callers_with_lsp("create_data")
+        .get_callers("create_data", tethys::CallerMode::LspRefined)
         .expect("get_callers failed");
 
     assert!(
@@ -606,7 +606,7 @@ pub fn use_string_container() -> String {
 
     // Verify Container methods are found
     let new_callers = tethys
-        .get_callers_with_lsp("Container::new")
+        .get_callers("Container::new", tethys::CallerMode::LspRefined)
         .expect("get_callers for Container::new failed");
 
     assert!(
@@ -617,7 +617,7 @@ pub fn use_string_container() -> String {
     );
 
     let get_callers = tethys
-        .get_callers_with_lsp("Container::get")
+        .get_callers("Container::get", tethys::CallerMode::LspRefined)
         .expect("get_callers for Container::get failed");
 
     assert!(

--- a/tests/macro_token_refs.rs
+++ b/tests/macro_token_refs.rs
@@ -298,7 +298,12 @@ fn macro_call_excluded_from_call_edges_and_callers() {
         )
         .expect("helper symbol");
     let callers = tethys
-        .get_callers(&qualified, false)
+        .get_callers(
+            &qualified,
+            tethys::CallerMode::Indexed {
+                call_edges: tethys::CallEdgeSelection::All,
+            },
+        )
         .expect("get_callers succeeds");
     assert!(
         callers.is_empty(),

--- a/tests/method_calls.rs
+++ b/tests/method_calls.rs
@@ -277,13 +277,18 @@ fn ticket_repro_all_three_acceptance_criteria() {
         "expected a name-arm bind, got {strategy:?}"
     );
     let callers = tethys
-        .get_callers("Thing::unwrap", false)
+        .get_callers(
+            "Thing::unwrap",
+            tethys::CallerMode::Indexed {
+                call_edges: tethys::CallEdgeSelection::All,
+            },
+        )
         .expect("callers query");
     let caller_files: Vec<&str> = callers.iter().map(|c| c.file.to_str().unwrap()).collect();
     assert_eq!(caller_files, ["src/lib.rs"], "one caller file");
     let all_symbols: Vec<&str> = callers
         .iter()
-        .flat_map(|c| c.symbols_used.iter().map(String::as_str))
+        .map(|caller| caller.symbol.qualified_name.as_str())
         .collect();
     assert!(
         all_symbols.iter().any(|s| s.contains("use_internal")),

--- a/tests/pass2_crate_root_paths.rs
+++ b/tests/pass2_crate_root_paths.rs
@@ -174,13 +174,18 @@ fn callers_includes_qualified_only_call_site() {
     tethys.index().expect("index failed");
 
     let callers = tethys
-        .get_callers("helper", false)
+        .get_callers(
+            "helper",
+            tethys::CallerMode::Indexed {
+                call_edges: tethys::CallEdgeSelection::All,
+            },
+        )
         .expect("get_callers failed");
-    // One Dependent per caller symbol (not per file): aggregate b.rs rows.
+    // One Caller per calling symbol, even when callers share an indexed file.
     let b_rs_symbols: Vec<&str> = callers
         .iter()
-        .filter(|d| d.file.to_string_lossy().replace('\\', "/") == "src/b.rs")
-        .flat_map(|d| d.symbols_used.iter().map(String::as_str))
+        .filter(|caller| caller.file.to_string_lossy().replace('\\', "/") == "src/b.rs")
+        .map(|caller| caller.symbol.qualified_name.as_str())
         .collect();
     assert!(
         b_rs_symbols.contains(&"use_it_qualified"),

--- a/tests/strategy.rs
+++ b/tests/strategy.rs
@@ -402,11 +402,16 @@ fn exclude_speculative_drops_only_unsupported() {
     let (_dir, tethys) = exclusion_fixture();
 
     let callers_of = |name: &str, exclude: bool| -> Vec<String> {
+        let call_edges = if exclude {
+            tethys::CallEdgeSelection::ExcludeSpeculative
+        } else {
+            tethys::CallEdgeSelection::All
+        };
         let mut v: Vec<String> = tethys
-            .get_callers(name, exclude)
+            .get_callers(name, tethys::CallerMode::Indexed { call_edges })
             .expect("callers")
             .into_iter()
-            .flat_map(|d| d.symbols_used)
+            .map(|caller| caller.symbol.qualified_name)
             .collect();
         v.sort_unstable();
         v
@@ -482,4 +487,24 @@ fn cli_callers_exclude_speculative() {
         run(&["--transitive", "--exclude-speculative"]).contains("No callers found"),
         "flag composes with --transitive through get_symbol_impact"
     );
+}
+
+#[test]
+fn cli_callers_rejects_unsupported_lsp_combinations() {
+    for conflicting_flag in ["--transitive", "--exclude-speculative"] {
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_tethys"))
+            .args(["callers", "leaf", "--lsp", conflicting_flag])
+            .output()
+            .expect("run callers");
+
+        assert!(
+            !output.status.success(),
+            "--lsp with {conflicting_flag} must fail"
+        );
+        let stderr = String::from_utf8(output.stderr).expect("utf8 stderr");
+        assert!(
+            stderr.contains("cannot be used with") && stderr.contains(conflicting_flag),
+            "explicit conflict error for {conflicting_flag}, got: {stderr}"
+        );
+    }
 }


### PR DESCRIPTION
Implements rivets **tethys-5n64** — callers: make direct caller modes explicit and evidence-accurate.

## What

- Direct caller queries now take an explicit `CallerMode` at the Tethys seam: `Indexed { call_edges }` (with `CallEdgeSelection::All` / `ExcludeSpeculative`) or `LspRefined`.
- Caller results are caller-specific (`Caller { symbol, file }`) instead of overloading the generic dependent projection; the direct-caller SQL hydrates indexed files in the graph query (single statement, no per-result lookup) and selects `s.is_test` so caller symbols no longer misreport test status.
- The CLI rejects `--lsp` with `--transitive` or `--exclude-speculative` instead of silently ignoring flags.
- LSP-refined mode waits for server readiness, targets `find_references` at the declaration's name identifier, attributes references to their innermost containing symbol, and merges/dedupes with indexed findings by caller symbol id.

## Review

Two-axis review (`/code-review commit 2425521`) assessed per `gilfoyle:assessing-review-feedback`; 12 findings, 2 applied, 2 tracker updates, 8 rejected (3 as duplicates of tracked work). Follow-up commits:

- `test(callers): fence lsp caller merge dedup at the seam` — extracted `Tethys::merge_lsp_reference_callers` and fenced merge/dedup/attribution with fabricated LSP locations, so the merge criterion is exercised in regular CI without rust-analyzer (real-server asserts remain tethys-ot0z scope).
- `refactor(graph): use imported caller types over full paths` — import tidy in `tests/graph.rs` / `src/db/graph.rs`.

## Review-feedback decisions

| # | Finding (one line) | Category | Verified? | Decision | Note |
|---|---|---|---|---|---|
| 1 | Merge/dedup AC fenced only by `#[ignore]`d test; new non-ignored dedup test vacuous without rust-analyzer | Bug (test coverage) | Yes — CI never runs `--ignored`; serverless LspRefined degrades to indexed-only where dupes are impossible | **Modify** | CI-safe seam fence added (see above); noted on tethys-ot0z |
| 2 | Scope creep: name-position retargeting, readiness wait, containing-line lookup | Design | Yes | **Reject (keep)** | Prerequisites for LspRefined correctness, not gold-plating |
| 3 | Undeclared latent-bug fix: `is_test` read `ce.call_count` at column 13 | Tracker hygiene | Yes — open tethys-6bui covers the class | **Accept (note)** | Partial absorption recorded on tethys-6bui; callees/transitive remain its scope. Not CLI-visible → no changelog fragment |
| 4 | `install_hint` printed twice in LSP startup warning | Polish | Refuted — identical field+message pattern pre-exists at two sites | **Reject** | Established convention (structured field + human-readable hint) |
| 5 | Transitive path fabricates `line_count` from `reference_count` | Design | Yes | **Reject (defer)** | Duplicate of tethys-u1rs (blocked-by 5n64; its AC names this) |
| 6 | Repeated bool→`CallEdgeSelection` mapping ×3 | Smell | Yes | **Reject (defer)** | Tracked at tethys-u1rs; transitive site dissolves there, CLI boundary is the natural flag→enum home |
| 7 | Residual `exclude_speculative: bool` on transitive APIs | Design | Yes | **Reject (defer)** | Same surface tethys-u1rs reworks |
| 8 | `CallerMode::Indexed { call_edges: All }` boilerplate; convenience ctor | Polish | Yes — 22 sites | **Reject** | Explicit mode is self-documenting; contra tethys-6k6b interface minimization |
| 9 | Import inconsistency in tests/graph.rs + db/graph.rs | Style | Yes | **Accept** | Mechanical tidy commit |
| 10 | `(u32, u32)` position tuples; index base in comments | Smell | Yes | **Reject** | Codebase-wide convention; tethys-2d1x chose comment encoding-fences |
| 11 | Speculative generality: `definition_name_position` trait default | Smell | Refuted — dispatches on `self.tree_sitter_language()`; language behavior belongs behind `LanguageSupport` | **Reject** | Repo seam standard overrides baseline smell |
| 12 | Divergent change: reshaping bundled with behavior fixes | Smell | Yes | **Reject** | Fixes entangled with the retargeting that makes LspRefined correct; no repo standard mandates split |

Changelog fragment: `changelog.d/tethys-5n64.changed.md`.
