### PR TITLE
refactor(callers): apply fde3638 review-feedback decisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ For "what is X / how do I call X / how does process Y work", route via
 | `src/cargo.rs` | Cargo workspace/crate discovery (public) |
 | `src/languages/` | Per-language extraction: `LanguageSupport` + `ModuleResolver` (rust.rs, csharp.rs, module_resolver.rs, common.rs) |
 | `src/db/` | SQLite layer: `Index` + submodules (symbols, references, imports, call_edges, file_deps, graph, architecture, panic_points, files, schema, helpers) |
-| `src/graph/` | Internal graph query DTOs; concrete traversal queries live on `db::Index` |
+| `src/graph/` | Graph query result DTOs (public ones, e.g. `SymbolImpact`, re-export via `lib.rs`); concrete traversal queries live on `db::Index` |
 | `src/lsp/` | LSP client transport + providers (optional refinement) |
 | `src/cli/` | One module per CLI command + display/helpers |
 | `tests/` | Integration tests, incl. `seam_lint.rs` (architectural invariant) |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -211,7 +211,9 @@ database — enforced by the seam lint.
 
 **Impact**:
 Given a target file or symbol, the files and symbols that depend on it — direct and
-transitive dependents. Answers "what could break if I change this."
+transitive dependents. Answers "what could break if I change this." Symbol impact
+reports **callers** at their minimum call depth (no reference counts); file impact
+reports dependent files.
 _Avoid_: blast radius
 
 **Reachability**:

--- a/benches/queries.rs
+++ b/benches/queries.rs
@@ -227,7 +227,7 @@ fn bench_get_symbol_impact_depth(c: &mut Criterion) {
             b.iter(|| {
                 let impact = workspace
                     .tethys
-                    .get_symbol_impact("depth0_func", None, false)
+                    .get_symbol_impact("depth0_func", None, tethys::CallEdgeSelection::All)
                     .expect("get_symbol_impact failed");
                 black_box(impact)
             });
@@ -255,7 +255,7 @@ fn bench_get_symbol_impact_mixed(c: &mut Criterion) {
             b.iter(|| {
                 let impact = workspace
                     .tethys
-                    .get_symbol_impact("core_compute", None, false)
+                    .get_symbol_impact("core_compute", None, tethys::CallEdgeSelection::All)
                     .expect("get_symbol_impact failed");
                 black_box(impact)
             });

--- a/docs/reviews/2026-07-24-fde3638-review-decisions.md
+++ b/docs/reviews/2026-07-24-fde3638-review-decisions.md
@@ -1,0 +1,18 @@
+# Review-feedback decisions — fde3638 (feat(callers): return depth-accurate symbol impact)
+
+Two-axis review (`/code-review fde3638`, standards + spec sub-agents) assessed via
+`gilfoyle:assessing-review-feedback`. Six findings; each verified against the code
+and the rivets tracker before any change was applied.
+
+| # | Finding (one line) | Axis | Category | Verified? | Decision | Note |
+|---|---|---|---|---|---|---|
+| 1 | AGENTS.md module map still calls graph DTOs "Internal" after `SymbolImpact`/`SymbolImpactCaller` went public | Standards | Convention (documented: AGENTS.md doc-maintenance rule) | Yes — AGENTS.md:59 contradicted lib.rs:59 and AGENTS.md:34 | Accept | `79fec60` — one-line map correction |
+| 2 | CONTEXT.md **Impact** entry frames symbol impact as generic "dependents" | Standards | Convention (soft) | Yes — entry not false (callers are dependents) but imprecise for the new depth vocabulary | Modify | `d792869` — one-line clarification; full seam/vocabulary rewrite already tracked at tethys-71if |
+| 3 | bool→`CallEdgeSelection` mapping duplicated (cli/callers.rs + lib.rs); facade takes a bare `bool` | Standards | Design | Yes — plus `cli/impact.rs` passed an unreadable bare `false` | Modify | `c28be7e` — took the facade-enum variant over the suggested `From<bool>`: matches the documented explicit-modes seam invariant; ~25 mechanical call sites, fenced by the existing suite |
+| 4 | `direct_callers`/`transitive_callers` each recompute `partition_point`; ordering precondition undocumented on `new` | Standards | Polish | Yes | Accept | `3d803b6` — private `direct_end()` + precondition doc on `new`; skipped a `debug_assert` since ordering is already fenced by the depth-contract test |
+| 5 | `use cli::callers::run as run_callers` alias inconsistent with the other 15 command dispatches | Standards | Style | Yes — no name collision justifies the alias | Accept | `581f374` — inline `cli::callers::run(...)` |
+| 6 | No CLI-level happy-path test for `impact --symbol` depth-partitioned output | Spec | Test coverage | Yes — only the LSP-rejection CLI test existed | Accept | `c02ccb6` — new strategy test asserts direct/transitive sectioning and `--depth 1` trimming on the exclusion fixture |
+
+Spec-axis scope-creep notes (`run_command` extraction; dropped genuine
+`ce.call_count` on the direct path) were assessed as benign — no observable
+behavior change at the public seam — and left as-is.

--- a/src/cli/callers.rs
+++ b/src/cli/callers.rs
@@ -22,8 +22,14 @@ pub fn run(
 
     let tethys = Tethys::new(workspace)?;
 
+    let call_edges = if exclude_speculative {
+        CallEdgeSelection::ExcludeSpeculative
+    } else {
+        CallEdgeSelection::All
+    };
+
     if transitive {
-        let impact = tethys.get_symbol_impact(symbol, depth, exclude_speculative)?;
+        let impact = tethys.get_symbol_impact(symbol, depth, call_edges)?;
 
         if impact.callers().is_empty() {
             println!("No callers found for \"{}\"", symbol.cyan());
@@ -58,13 +64,7 @@ pub fn run(
         let mode = if lsp {
             CallerMode::LspRefined
         } else {
-            CallerMode::Indexed {
-                call_edges: if exclude_speculative {
-                    CallEdgeSelection::ExcludeSpeculative
-                } else {
-                    CallEdgeSelection::All
-                },
-            }
+            CallerMode::Indexed { call_edges }
         };
         let callers = tethys.get_callers(symbol, mode)?;
 

--- a/src/cli/impact.rs
+++ b/src/cli/impact.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use colored::Colorize;
-use tethys::{Impact, SymbolImpact, Tethys};
+use tethys::{CallEdgeSelection, Impact, SymbolImpact, Tethys};
 
 use super::display::{print_dependents, print_symbol_impact_callers_by_file};
 use super::ensure_lsp_if_requested;
@@ -21,7 +21,7 @@ pub fn run(
     let tethys = Tethys::new(workspace)?;
 
     if is_symbol {
-        let impact = tethys.get_symbol_impact(target, depth, false)?;
+        let impact = tethys.get_symbol_impact(target, depth, CallEdgeSelection::All)?;
         println!("Impact analysis for symbol \"{}\":", target.cyan().bold());
         print_symbol_impact_analysis(&impact);
     } else {

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -24,8 +24,15 @@ pub struct SymbolImpact {
 }
 
 impl SymbolImpact {
+    /// `callers` must be sorted by minimum depth ascending (the SQL traversal
+    /// orders by `min_depth`); the direct/transitive split relies on it.
     pub(crate) fn new(target: Symbol, callers: Vec<SymbolImpactCaller>) -> Self {
         Self { target, callers }
+    }
+
+    /// Index of the first caller past the depth-one prefix.
+    fn direct_end(&self) -> usize {
+        self.callers.partition_point(|caller| caller.depth == 1)
     }
 
     /// All callers, ordered by minimum depth and then qualified name.
@@ -37,15 +44,13 @@ impl SymbolImpact {
     /// Callers whose minimum depth is one.
     #[must_use]
     pub fn direct_callers(&self) -> &[SymbolImpactCaller] {
-        let direct_end = self.callers.partition_point(|caller| caller.depth == 1);
-        &self.callers[..direct_end]
+        &self.callers[..self.direct_end()]
     }
 
     /// Callers whose minimum depth is greater than one.
     #[must_use]
     pub fn transitive_callers(&self) -> &[SymbolImpactCaller] {
-        let direct_end = self.callers.partition_point(|caller| caller.depth == 1);
-        &self.callers[direct_end..]
+        &self.callers[self.direct_end()..]
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,13 +470,13 @@ impl Tethys {
     /// are capped (with a `warn!` log) since the underlying SQL CTE depth is a
     /// `u32`.
     ///
-    /// `exclude_speculative` drops call edges whose every supporting reference
-    /// bands speculative at every traversal hop (see [`Tethys::get_callers`]).
+    /// `call_edges` selects which retained call edges the traversal follows
+    /// at every hop (see [`CallEdgeSelection`]).
     pub fn get_symbol_impact(
         &self,
         qualified_name: &str,
         max_depth: Option<usize>,
-        exclude_speculative: bool,
+        call_edges: CallEdgeSelection,
     ) -> Result<SymbolImpact> {
         let symbol = self
             .db
@@ -484,11 +484,6 @@ impl Tethys {
             .ok_or_else(|| Error::NotFound(format!("symbol: {qualified_name}")))?;
 
         let depth = max_depth.map_or(db::DEFAULT_MAX_DEPTH, saturating_depth_to_u32);
-        let call_edges = if exclude_speculative {
-            CallEdgeSelection::ExcludeSpeculative
-        } else {
-            CallEdgeSelection::All
-        };
         let callers = self
             .db
             .get_transitive_callers(symbol.id, depth, call_edges)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use colored::Colorize;
 use tracing_subscriber::EnvFilter;
 
 mod cli;
-use cli::callers::run as run_callers;
 
 /// Tethys: Code intelligence cache and query interface.
 #[derive(Parser)]
@@ -301,7 +300,7 @@ fn run_command(workspace: &Path, command: Commands) -> Result<(), tethys::Error>
             depth,
             lsp,
             exclude_speculative,
-        } => run_callers(
+        } => cli::callers::run(
             workspace,
             &symbol,
             transitive,

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -209,10 +209,10 @@ fn get_symbol_impact_max_depth_limits_transitive_traversal() {
     // direct callers (no transitive hops), and direct callers must be
     // invariant under max_depth.
     let depth_1 = tethys
-        .get_symbol_impact("Connection", Some(1), false)
+        .get_symbol_impact("Connection", Some(1), CallEdgeSelection::All)
         .expect("get_symbol_impact depth=1 failed");
     let unbounded = tethys
-        .get_symbol_impact("Connection", None, false)
+        .get_symbol_impact("Connection", None, CallEdgeSelection::All)
         .expect("get_symbol_impact default depth failed");
 
     assert!(
@@ -870,7 +870,7 @@ fn get_symbol_impact_returns_error_for_nonexistent_symbol() {
     let (_dir, mut tethys) = workspace_with_call_graph();
     tethys.index().expect("index failed");
 
-    let result = tethys.get_symbol_impact("NoSuchSymbol", None, false);
+    let result = tethys.get_symbol_impact("NoSuchSymbol", None, CallEdgeSelection::All);
 
     assert!(
         result.is_err(),
@@ -889,7 +889,7 @@ fn get_symbol_impact_reports_callers_at_their_minimum_depth() {
     tethys.index().expect("index failed");
 
     let impact = tethys
-        .get_symbol_impact("Helper::check", None, false)
+        .get_symbol_impact("Helper::check", None, CallEdgeSelection::All)
         .expect("get_symbol_impact for Helper::check should succeed");
 
     assert_eq!(impact.target.qualified_name, "Helper::check");
@@ -936,7 +936,7 @@ fn get_symbol_impact_returns_each_caller_once_at_shortest_depth() {
     tethys.index().expect("index failed");
 
     let impact = tethys
-        .get_symbol_impact("leaf", None, false)
+        .get_symbol_impact("leaf", None, CallEdgeSelection::All)
         .expect("get_symbol_impact for leaf should succeed");
     let callers: Vec<_> = impact
         .callers()
@@ -981,29 +981,29 @@ fn get_symbol_impact_obeys_the_shared_depth_contract() {
     tethys.index().expect("index failed");
 
     let zero = tethys
-        .get_symbol_impact("Helper::check", Some(0), false)
+        .get_symbol_impact("Helper::check", Some(0), CallEdgeSelection::All)
         .expect("depth zero should validate the target");
     assert_eq!(zero.target.qualified_name, "Helper::check");
     assert!(zero.callers().is_empty(), "depth zero traverses no edges");
     assert!(
         tethys
-            .get_symbol_impact("NoSuchSymbol", Some(0), false)
+            .get_symbol_impact("NoSuchSymbol", Some(0), CallEdgeSelection::All)
             .is_err(),
         "depth zero still validates the requested target"
     );
 
     let one = tethys
-        .get_symbol_impact("Helper::check", Some(1), false)
+        .get_symbol_impact("Helper::check", Some(1), CallEdgeSelection::All)
         .expect("depth one impact");
     assert_eq!(caller_depths(&one), [("validate", 1)]);
 
     let two = tethys
-        .get_symbol_impact("Helper::check", Some(2), false)
+        .get_symbol_impact("Helper::check", Some(2), CallEdgeSelection::All)
         .expect("depth two impact");
     assert_eq!(caller_depths(&two), [("validate", 1), ("process", 2)]);
 
     let default = tethys
-        .get_symbol_impact("Helper::check", None, false)
+        .get_symbol_impact("Helper::check", None, CallEdgeSelection::All)
         .expect("default depth impact");
     assert_eq!(
         caller_depths(&default),
@@ -1013,7 +1013,7 @@ fn get_symbol_impact_obeys_the_shared_depth_contract() {
 
     let oversized = usize::try_from(u64::from(u32::MAX) + 1).unwrap_or(usize::MAX);
     let saturated = tethys
-        .get_symbol_impact("Helper::check", Some(oversized), false)
+        .get_symbol_impact("Helper::check", Some(oversized), CallEdgeSelection::All)
         .expect("oversized depth impact");
     assert_eq!(
         caller_depths(&saturated),
@@ -1029,7 +1029,7 @@ fn get_symbol_impact_returns_empty_for_uncalled_symbol() {
 
     // process is never called by other symbols
     let impact = tethys
-        .get_symbol_impact("process", None, false)
+        .get_symbol_impact("process", None, CallEdgeSelection::All)
         .expect("get_symbol_impact for process should succeed");
 
     assert!(
@@ -1051,7 +1051,7 @@ fn get_symbol_impact_finds_direct_callers() {
 
     // validate is called by process directly
     let impact = tethys
-        .get_symbol_impact("validate", None, false)
+        .get_symbol_impact("validate", None, CallEdgeSelection::All)
         .expect("get_symbol_impact for validate should succeed");
 
     assert!(
@@ -1066,7 +1066,7 @@ fn get_symbol_impact_targets_correct_symbol() {
     tethys.index().expect("index failed");
 
     let impact = tethys
-        .get_symbol_impact("validate", None, false)
+        .get_symbol_impact("validate", None, CallEdgeSelection::All)
         .expect("get_symbol_impact for validate should succeed");
 
     assert_eq!(
@@ -1082,7 +1082,7 @@ fn get_symbol_impact_cross_file_resolved() {
 
     // Connection's callers are cross-file - now resolved in Pass 2
     let impact = tethys
-        .get_symbol_impact("Connection", None, false)
+        .get_symbol_impact("Connection", None, CallEdgeSelection::All)
         .expect("get_symbol_impact for Connection should succeed");
 
     assert!(
@@ -1252,7 +1252,7 @@ fn transitive_callers_via_call_edges() {
     // Helper::check is called by validate, which is called by process
     // So Helper::check should have process as a transitive caller
     let impact = tethys
-        .get_symbol_impact("Helper::check", None, false)
+        .get_symbol_impact("Helper::check", None, CallEdgeSelection::All)
         .expect("get_symbol_impact for Helper::check should succeed");
 
     let total = impact.callers().len();

--- a/tests/strategy.rs
+++ b/tests/strategy.rs
@@ -592,3 +592,52 @@ fn cli_symbol_impact_rejects_lsp() {
         "explicit conflict error for symbol impact with LSP, got: {stderr}"
     );
 }
+
+/// The `impact --symbol` happy path renders callers partitioned by depth:
+/// `b_fn` is direct, `a_fn` transitive, and `--depth 1` trims the
+/// transitive tier to its empty label.
+#[test]
+fn cli_symbol_impact_renders_depth_partitioned_callers() {
+    let (dir, _tethys) = exclusion_fixture();
+    let run = |extra: &[&str]| -> String {
+        let output = std::process::Command::new(env!("CARGO_BIN_EXE_tethys"))
+            .args(["impact", "leaf", "--symbol", "-w"])
+            .arg(dir.path())
+            .args(extra)
+            .output()
+            .expect("run symbol impact");
+        assert!(
+            output.status.success(),
+            "symbol impact should succeed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).expect("utf8 stdout")
+    };
+
+    let full = run(&[]);
+    let direct_at = full.find("Direct callers").expect("direct section");
+    let transitive_at = full.find("Transitive callers").expect("transitive section");
+    assert!(direct_at < transitive_at, "direct section renders first");
+    assert!(
+        full[direct_at..transitive_at].contains("b_fn"),
+        "direct caller lands in the direct section: {full}"
+    );
+    assert!(
+        full[transitive_at..].contains("a_fn"),
+        "transitive caller lands in the transitive section: {full}"
+    );
+
+    let trimmed = run(&["--depth", "1"]);
+    assert!(
+        trimmed.contains("b_fn"),
+        "depth one keeps the direct caller: {trimmed}"
+    );
+    assert!(
+        !trimmed.contains("a_fn"),
+        "depth one drops the transitive caller: {trimmed}"
+    );
+    assert!(
+        trimmed.contains("(none beyond direct)"),
+        "empty transitive tier is labeled: {trimmed}"
+    );
+}

--- a/tests/strategy.rs
+++ b/tests/strategy.rs
@@ -440,7 +440,7 @@ fn exclusion_is_transitive() {
     let (_dir, tethys) = exclusion_fixture();
 
     let full = tethys
-        .get_symbol_impact("leaf", None, false)
+        .get_symbol_impact("leaf", None, tethys::CallEdgeSelection::All)
         .expect("impact");
     let all: Vec<_> = full
         .callers()
@@ -450,7 +450,7 @@ fn exclusion_is_transitive() {
     assert_eq!(all, ["b_fn", "a_fn"], "unfiltered chain reaches a_fn");
 
     let filtered = tethys
-        .get_symbol_impact("leaf", None, true)
+        .get_symbol_impact("leaf", None, tethys::CallEdgeSelection::ExcludeSpeculative)
         .expect("impact excl");
     assert!(
         filtered.callers().is_empty(),
@@ -465,7 +465,7 @@ fn exclusion_preserves_mixed_support_across_transitive_hops() {
     let (_dir, tethys) = exclusion_fixture();
 
     let impact = tethys
-        .get_symbol_impact("ml", None, true)
+        .get_symbol_impact("ml", None, tethys::CallEdgeSelection::ExcludeSpeculative)
         .expect("filtered impact");
     let callers: Vec<_> = impact
         .callers()


### PR DESCRIPTION
Follow-ups from a two-axis review (`/code-review fde3638`) of the depth-accurate
symbol-impact feature, triaged per-finding via `gilfoyle:assessing-review-feedback`.
Six findings verified; three applied as proposed, three with a modified fix. Full
decision log: `docs/reviews/2026-07-24-fde3638-review-decisions.md` (in this PR).

## Changes

- **AGENTS.md / CONTEXT.md** — module map no longer calls the graph result DTOs
  internal; the Impact glossary entry notes symbol impact reports callers at
  minimum depth (full vocabulary rewrite stays with tethys-71if).
- **`Tethys::get_symbol_impact` now takes `CallEdgeSelection`** instead of a bare
  `exclude_speculative: bool` — aligns the facade with the documented
  explicit-modes seam invariant, removes the duplicated bool→enum mapping, and
  makes call sites self-describing (`cli/impact.rs` previously passed an opaque
  `false`). Mechanical update across CLI, benches, and tests; no behavior change.
- **`SymbolImpact`** — shared `direct_end()` partition point; sorted-by-depth
  precondition documented on `new`.
- **`main.rs`** — callers dispatches inline like the other fifteen commands
  (dropped the `run_callers` alias).
- **New CLI test** — `impact --symbol` happy path asserting direct/transitive
  sectioning and `--depth 1` trimming.

No CLI-visible behavior change, hence `skip-changelog`. No rivets issue closes
with this PR (review follow-up, not tracked work).

Gates: `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, full
`cargo nextest run` (1050 tests) all green at each commit.